### PR TITLE
change husky npm script from postinstall

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "nylas-use-cases",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:prettier": "prettier --write '**/*.js'",
     "lint:prettier:check": "prettier --check '**/*.js'",
     "lint:pretty-quick": "pretty-quick --staged",
-    "postinstall": "husky install"
+    "prep:husky": "npx husky install"
   },
   "devDependencies": {
     "concurrently": "^7.2.2",

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -45,8 +45,12 @@ async function getClientCredentials() {
   return client;
 }
 
+const ignoreFiles = ['.DS_Store'];
+
 async function getUseCases() {
-  const useCases = await fs.readdirSync(`${projectRoot}/packages`);
+  const useCases = await fs
+    .readdirSync(`${projectRoot}/packages`)
+    .filter((file) => !ignoreFiles.includes(file));
   const selectedUseCase = await inquirer.prompt([
     {
       type: 'list',
@@ -60,12 +64,13 @@ async function getUseCases() {
 }
 
 async function getFrameworkOptions(useCase) {
-  const serverOptions = await fs.readdirSync(
-    `${projectRoot}/packages/${useCase}/server`
-  );
-  const clientOptions = await fs.readdirSync(
-    `${projectRoot}/packages/${useCase}/client`
-  );
+  const serverOptions = await fs
+    .readdirSync(`${projectRoot}/packages/${useCase}/server`)
+    .filter((file) => !ignoreFiles.includes(file));
+
+  const clientOptions = await fs
+    .readdirSync(`${projectRoot}/packages/${useCase}/client`)
+    .filter((file) => !ignoreFiles.includes(file));
 
   return { server: serverOptions, client: clientOptions };
 }


### PR DESCRIPTION
# Description
<!-- Add information about what your PR achieves -->
- pre-commit is only required for those contributing and our internal team, this repo is used in our sample code download functionality where pre-commit hooks are not required so I am removing it from `postinstall` npm script.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.