### PR TITLE
fix ServerBindings.express in all server.js samples

### DIFF
--- a/packages/read-and-create-calendar-events/client/react/package.json
+++ b/packages/read-and-create-calendar-events/client/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "frontend",
+  "name": "nylas-read-send-calendar-events-react",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/packages/read-and-create-calendar-events/server/node-express/package.json
+++ b/packages/read-and-create-calendar-events/server/node-express/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nylas-read-and-create-calendar-events-node-express",
+  "name": "nylas-read-send-calendar-events-node-express",
   "version": "0.1.0",
   "description": "Demo using the Nylas Node SDK and ExpressJS.",
   "main": "server.js",

--- a/packages/read-and-create-calendar-events/server/node-express/server.js
+++ b/packages/read-and-create-calendar-events/server/node-express/server.js
@@ -22,12 +22,12 @@ const nylasClient = new Nylas({
 });
 
 // The uri for the frontend
-const clientUri = 'http://localhost:3000';
+const CLIENT_URI = `http://localhost:${process.env.PORT || 3000}`;
 
 // Before we start our backend, we should whitelist our frontend as a redirect URI to ensure the auth completes
 nylasClient
   .application({
-    redirectUris: [clientUri],
+    redirectUris: [CLIENT_URI],
   })
   .then((applicationDetails) => {
     console.log(
@@ -66,7 +66,7 @@ const startExpress = () => {
   const expressBinding = new ServerBindings.express(nylasClient, {
     defaultScopes: [Scope.Calendar],
     exchangeMailboxTokenCallback,
-    clientUri,
+    clientUri: CLIENT_URI,
   });
 
   // Mount the express middleware to your express app

--- a/packages/read-emails/client/react/package.json
+++ b/packages/read-emails/client/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "frontend",
+  "name": "nylas-read-emails-react",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/packages/read-emails/server/node-express/package-lock.json
+++ b/packages/read-emails/server/node-express/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nylas-express-example",
+  "name": "nylas-read-emails-node-express",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "nylas-express-example",
+      "name": "nylas-read-emails-node-express",
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {

--- a/packages/read-emails/server/node-express/package.json
+++ b/packages/read-emails/server/node-express/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nylas-express-example",
+  "name": "nylas-read-emails-node-express",
   "version": "0.1.0",
   "description": "Demo using the Nylas Node SDK and ExpressJS.",
   "main": "server.js",

--- a/packages/read-emails/server/node/package.json
+++ b/packages/read-emails/server/node/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nylas-node-example",
+  "name": "nylas-read-emails-node",
   "version": "0.1.0",
   "description": "Demo using the Nylas Node SDK and any Node JS-compatible server framework.",
   "main": "server.js",

--- a/packages/read-emails/server/node/server.js
+++ b/packages/read-emails/server/node/server.js
@@ -22,12 +22,12 @@ const nylasClient = new Nylas({
 });
 
 // The uri for the frontend
-const clientUri = 'http://localhost:3000';
+const CLIENT_URI = `http://localhost:${process.env.PORT || 3000}`;
 
 // Before we start our backend, we should whitelist our frontend as a redirect URI to ensure the auth completes
 nylasClient
   .application({
-    redirectUris: [clientUri],
+    redirectUris: [CLIENT_URI],
   })
   .then((applicationDetails) => {
     console.log(
@@ -71,7 +71,7 @@ const startServer = () => {
       scopes: [Scope.EmailReadOnly],
       emailAddress: body.email_address,
       successUrl: body.success_url,
-      clientUri,
+      clientUri: CLIENT_URI,
     });
 
     res.writeHead(200).end(authUrl);

--- a/packages/send-and-read-emails/client/react/package.json
+++ b/packages/send-and-read-emails/client/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "frontend",
+  "name": "nylas-send-read-emails-react",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/packages/send-and-read-emails/server/node-express/package.json
+++ b/packages/send-and-read-emails/server/node-express/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nylas-express-example",
+  "name": "nylas-send-read-emails-node-express",
   "version": "0.1.0",
   "description": "Demo using the Nylas Node SDK and ExpressJS.",
   "main": "server.js",

--- a/packages/send-and-read-emails/server/node-express/server.js
+++ b/packages/send-and-read-emails/server/node-express/server.js
@@ -46,7 +46,7 @@ const app = express();
 app.use(cors());
 
 // The uri for the frontend
-const CLIENT_URI = 'http://localhost:3000';
+const CLIENT_URI = `http://localhost:${process.env.PORT || 3000}`;
 
 // Before we start our backend, we should whitelist our frontend as a redirect URI to ensure the auth completes
 nylasClient

--- a/packages/send-and-read-emails/server/node/package.json
+++ b/packages/send-and-read-emails/server/node/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nylas-node-example",
+  "name": "nylas-send-read-emails-node",
   "version": "0.1.0",
   "description": "Demo using the Nylas Node SDK and any Node JS-compatible server framework.",
   "main": "server.js",

--- a/packages/send-and-read-emails/server/node/server.js
+++ b/packages/send-and-read-emails/server/node/server.js
@@ -44,7 +44,7 @@ const exchangeMailboxTokenCallback = async (accessTokenObj, res) => {
 };
 
 // The uri for the frontend
-const CLIENT_URI = 'http://localhost:3000';
+const CLIENT_URI = `http://localhost:${process.env.PORT || 3000}`;
 
 // Before we start our backend, we should whitelist our frontend as a redirect URI to ensure the auth completes
 nylasClient
@@ -71,7 +71,7 @@ mockServer.post(DefaultPaths.buildAuthUrl, async (req, res) => {
     scopes: [Scope.EmailReadOnly],
     emailAddress: body.email_address,
     successUrl: body.success_url,
-    CLIENT_URI,
+    clientUri: CLIENT_URI,
   });
 
   res.writeHead(200).end(authUrl);

--- a/packages/send-emails/server/node-express/server.js
+++ b/packages/send-emails/server/node-express/server.js
@@ -22,12 +22,12 @@ const nylasClient = new Nylas({
 });
 
 // The uri for the frontend
-const clientUri = 'http://localhost:3000';
+const CLIENT_URI = `http://localhost:${process.env.PORT || 3000}`;
 
 // Before we start our backend, we should whitelist our frontend as a redirect URI to ensure the auth completes
 nylasClient
   .application({
-    redirectUris: [clientUri],
+    redirectUris: [CLIENT_URI],
   })
   .then((applicationDetails) => {
     console.log(
@@ -43,11 +43,13 @@ const exchangeMailboxTokenCallback = async (accessTokenObj, res) => {
   const emailAddress = accessTokenObj.emailAddress;
   console.log('Access Token was generated for: ' + accessTokenObj.emailAddress);
 
+  // Replace this mock code with your actual database operations
   const user = await mockDb.createOrUpdateUser(emailAddress, {
     accessToken,
     emailAddress,
   });
 
+  // Replace this mock code with your actual database operations
   res.json({
     id: user.id,
     emailAddress: user.emailAddress,
@@ -64,7 +66,7 @@ const startExpress = () => {
   const expressBinding = new ServerBindings.express(nylasClient, {
     defaultScopes: [Scope.EmailModify, Scope.EmailSend],
     exchangeMailboxTokenCallback,
-    clientUri,
+    clientUri: CLIENT_URI,
   });
 
   // Mount the express middleware to your express app
@@ -103,7 +105,6 @@ const startExpress = () => {
     const requestBody = req.body;
 
     if (!req.headers.authorization) {
-      console.log('no headers');
       return res.json('Unauthorized');
     }
 

--- a/packages/send-emails/server/node/server.js
+++ b/packages/send-emails/server/node/server.js
@@ -23,12 +23,12 @@ const nylasClient = new Nylas({
 });
 
 // The uri for the frontend
-const clientUri = 'http://localhost:3000';
+const CLIENT_URI = `http://localhost:${process.env.PORT || 3000}`;
 
 // Before we start our backend, we should whitelist our frontend as a redirect URI to ensure the auth completes
 nylasClient
   .application({
-    redirectUris: [clientUri],
+    redirectUris: [CLIENT_URI],
   })
   .then((applicationDetails) => {
     console.log(
@@ -72,7 +72,7 @@ const startServer = () => {
       scopes: [Scope.EmailReadOnly],
       emailAddress: body.email_address,
       successUrl: body.success_url,
-      clientUri,
+      clientUri: CLIENT_URI,
     });
 
     res.writeHead(200).end(authUrl);

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -34,9 +34,7 @@ async function startSourceRepo() {
     },
   ]);
 
-  result.catch((error) => {
-    console.log('error:', error);
-  });
+  result.catch(() => {});
 }
 
 function startDownloadedRepo() {


### PR DESCRIPTION
# Description
<!-- Add information about what your PR achieves -->
- allow configurable client port via `PORT=3002 npm run start`
- fix `clientUri` key in `ServerBindings.express` options

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.