### PR TITLE
[send-and-read-emails] return only five threads

### DIFF
--- a/packages/send-and-read-emails/client/react/src/App.js
+++ b/packages/send-and-read-emails/client/react/src/App.js
@@ -131,7 +131,11 @@ function ReadEmails({ userId }) {
       </button>
       <div style={styles.ReadEmails.list}>
         {threads.map((thread) => (
-          <DisplayEmail subject={thread.subject} snippet={thread.snippet} />
+          <DisplayEmail
+            key={thread.id}
+            subject={thread.subject}
+            snippet={thread.snippet}
+          />
         ))}
       </div>
     </div>

--- a/packages/send-and-read-emails/server/node-express/route.js
+++ b/packages/send-and-read-emails/server/node-express/route.js
@@ -40,7 +40,7 @@ exports.readEmails = async (req, res, nylasClient) => {
 
   const nylas = nylasClient.with(user.accessToken);
 
-  const threads = await nylas.threads.list({ limit: 50 });
+  const threads = await nylas.threads.list({ limit: 5 });
 
   return res.json({ threads });
 };

--- a/packages/send-and-read-emails/server/node/route.js
+++ b/packages/send-and-read-emails/server/node/route.js
@@ -33,7 +33,7 @@ exports.readEmails = async (req, res, nylasClient) => {
   }
 
   const nylas = nylasClient.with(user.accessToken);
-  const threads = await nylas.threads.list({ limit: 50 });
+  const threads = await nylas.threads.list({ limit: 5 });
 
   return res.writeHead(200).end(JSON.stringify(threads));
 };


### PR DESCRIPTION
# Description
- Returns only 5 threads, instead of 50, for `send-and-read-emails` use case

- Added `key` prop to `DisplayEmail` component to remove the warning `Each child in a list should have a unique "key" prop.` in App.js for ReadEmails

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.