### PR TITLE
[read and create calendar events] Double webhook events when connecting an account

### DIFF
--- a/packages/read-and-create-calendar-events/client/react/src/App.js
+++ b/packages/read-and-create-calendar-events/client/react/src/App.js
@@ -9,27 +9,34 @@ function App() {
   const [primaryCalendar, setPrimaryCalendar] = useState(null);
 
   const serverBaseUrl = 'http://localhost:9000';
+
   const handleTokenExchange = (r) => {
     try {
-      const user = JSON.parse(r);
-      setUserId(user.id);
-      window.history.replaceState({}, '', `/?userId=${user.id}`);
-    } catch (err) {
-      console.warn('An error occurred parsing the response.');
-      window.history.replaceState({}, '', '/');
+      const { id } = JSON.parse(r);
+      setUserId(id);
+    } catch (e) {
+      console.error('An error occurred parsing the response.');
     }
   };
 
   useEffect(() => {
+    if (!nylas) {
+      return;
+    }
+
     const params = new URLSearchParams(window.location.search);
     if (params.has('code')) {
       nylas.exchangeCodeFromUrlForToken().then(handleTokenExchange);
     }
-
-    if (params.has('userId')) {
-      setUserId(params.get('userId'));
-    }
   }, [nylas]);
+
+  useEffect(() => {
+    if (userId.length) {
+      window.history.replaceState({}, '', `/?userId=${userId}`);
+    } else {
+      window.history.replaceState({}, '', '/');
+    }
+  }, [userId]);
 
   useEffect(() => {
     const getCalendars = async () => {


### PR DESCRIPTION
# Description

- Refactored `App.js`, so it doesn't call `handleTokenExchange()` more than once

- Moved updating of URL with `userId` to its own `useEffect` hook

- Removed duplicate `setUserId` invocation

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.