### PR TITLE
[send-emails] Double webhook events when connecting an account

### DIFF
--- a/packages/send-emails/client/react/src/App.js
+++ b/packages/send-emails/client/react/src/App.js
@@ -8,12 +8,10 @@ function App() {
 
   const handleTokenExchange = (r) => {
     try {
-      const user = JSON.parse(r);
-      setUserId(user.id);
-      window.history.replaceState({}, '', `/?userId=${user.id}`);
+      const { id } = JSON.parse(r);
+      setUserId(id);
     } catch (e) {
       console.error('An error occurred parsing the response.');
-      window.history.replaceState({}, '', '/');
     }
   };
 
@@ -26,13 +24,15 @@ function App() {
     if (params.has('code')) {
       nylas.exchangeCodeFromUrlForToken().then(handleTokenExchange);
     }
-
-    const userId = params.get('userId');
-
-    if (userId) {
-      setUserId(userId);
-    }
   }, [nylas]);
+
+  useEffect(() => {
+    if (userId.length) {
+      window.history.replaceState({}, '', `/?userId=${userId}`);
+    } else {
+      window.history.replaceState({}, '', '/');
+    }
+  }, [userId]);
 
   return (
     <div


### PR DESCRIPTION
# Description

- Refactored `App.js`, so it doesn't call `handleTokenExchange()` more than once

- Moved updating of URL with `userId` to its own `useEffect` hook

- Removed duplicate `setUserId` invocation

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.