### PR TITLE
Fixed incorrect data being populated for calendar usecase

### DIFF
--- a/packages/read-and-create-calendar-events/client/react/src/App.js
+++ b/packages/read-and-create-calendar-events/client/react/src/App.js
@@ -1,7 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { useNylas } from '@nylas/nylas-react';
 import { styles } from './styles';
-import { applyTimezone, displayMeetingTime, getLocalDateString } from './utils/date';
+import {
+  applyTimezone,
+  displayMeetingTime,
+  getLocalDateString,
+} from './utils/date';
 
 function App() {
   const nylas = useNylas();
@@ -52,7 +56,7 @@ function App() {
 
         let [calendar] = data.filter((calendar) => calendar.is_primary);
         // if no primary calendar, use the first one
-        if(!calendar && data.length) {
+        if (!calendar && data.length) {
           calendar = data[0];
         }
 
@@ -144,15 +148,21 @@ function Agenda({ serverBaseUrl, userId, calendarId }) {
 
   useEffect(() => {
     const getCalendarEvents = async () => {
-      if(calendarId) {
+      if (calendarId) {
         try {
           const startsAfter = null; // applyTimezone(getLocalDateString(new Date(new Date().setDate(new Date().getDate() - 7))));
-          const endsBefore = applyTimezone(getLocalDateString(new Date(new Date().setDate(new Date().getDate() + 7))));
+          const endsBefore = applyTimezone(
+            getLocalDateString(
+              new Date(new Date().setDate(new Date().getDate() + 7))
+            )
+          );
           const limit = 5;
 
           const url = `${serverBaseUrl}/nylas/read-events?${
             calendarId ? 'calendarId=' + calendarId : ''
-          }${startsAfter ? '&startsAfter=' + startsAfter : ''}${endsBefore ? '&endsBefore=' + endsBefore : ''}${limit ? '&limit=' + limit : ''}`;
+          }${startsAfter ? '&startsAfter=' + startsAfter : ''}${
+            endsBefore ? '&endsBefore=' + endsBefore : ''
+          }${limit ? '&limit=' + limit : ''}`;
 
           const res = await fetch(url, {
             method: 'GET',
@@ -230,7 +240,11 @@ function CalendarEventDate({ when }) {
 
 function CreateEventForm({ userId, serverBaseUrl, calendarId }) {
   const [startTime, setStartTime] = useState(getLocalDateString(new Date()));
-  const [endTime, setEndTime] = useState(getLocalDateString(new Date(new Date().setMinutes(new Date().getMinutes() + 30))));
+  const [endTime, setEndTime] = useState(
+    getLocalDateString(
+      new Date(new Date().setMinutes(new Date().getMinutes() + 30))
+    )
+  );
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
 

--- a/packages/read-and-create-calendar-events/client/react/src/App.js
+++ b/packages/read-and-create-calendar-events/client/react/src/App.js
@@ -157,7 +157,12 @@ function Agenda({ serverBaseUrl, userId, calendarId }) {
           const startsAfter = getTodaysDateTimestamp(); // today
           const endsBefore = getSevenDaysFromTodayDateTimestamp(); // 7 days from today
 
-          const queryParams = new URLSearchParams({ limit: 5, startsAfter, endsBefore, calendarId });
+          const queryParams = new URLSearchParams({
+            limit: 5,
+            startsAfter,
+            endsBefore,
+            calendarId,
+          });
 
           const url = `${serverBaseUrl}/nylas/read-events?${queryParams.toString()}`;
 

--- a/packages/read-and-create-calendar-events/client/react/src/App.js
+++ b/packages/read-and-create-calendar-events/client/react/src/App.js
@@ -3,8 +3,12 @@ import { useNylas } from '@nylas/nylas-react';
 import { styles } from './styles';
 import {
   applyTimezone,
+  currentTime,
+  currentTimePlusHalfHour,
   displayMeetingTime,
   getLocalDateString,
+  getSevenDaysFromTodayDateTimestamp,
+  getTodaysDateTimestamp,
 } from './utils/date';
 
 function App() {
@@ -150,19 +154,12 @@ function Agenda({ serverBaseUrl, userId, calendarId }) {
     const getCalendarEvents = async () => {
       if (calendarId) {
         try {
-          const startsAfter = null; // applyTimezone(getLocalDateString(new Date(new Date().setDate(new Date().getDate() - 7))));
-          const endsBefore = applyTimezone(
-            getLocalDateString(
-              new Date(new Date().setDate(new Date().getDate() + 7))
-            )
-          );
-          const limit = 5;
+          const startsAfter = getTodaysDateTimestamp(); // today
+          const endsBefore = getSevenDaysFromTodayDateTimestamp(); // 7 days from today
 
-          const url = `${serverBaseUrl}/nylas/read-events?${
-            calendarId ? 'calendarId=' + calendarId : ''
-          }${startsAfter ? '&startsAfter=' + startsAfter : ''}${
-            endsBefore ? '&endsBefore=' + endsBefore : ''
-          }${limit ? '&limit=' + limit : ''}`;
+          const url = `${serverBaseUrl}/nylas/read-events?limit=5&startsAfter=${startsAfter}&endsBefore=${endsBefore}${
+            calendarId ? '&calendarId=' + calendarId : ''
+          }`;
 
           const res = await fetch(url, {
             method: 'GET',
@@ -239,12 +236,8 @@ function CalendarEventDate({ when }) {
 }
 
 function CreateEventForm({ userId, serverBaseUrl, calendarId }) {
-  const [startTime, setStartTime] = useState(getLocalDateString(new Date()));
-  const [endTime, setEndTime] = useState(
-    getLocalDateString(
-      new Date(new Date().setMinutes(new Date().getMinutes() + 30))
-    )
-  );
+  const [startTime, setStartTime] = useState(currentTime());
+  const [endTime, setEndTime] = useState(currentTimePlusHalfHour());
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
 

--- a/packages/read-and-create-calendar-events/client/react/src/App.js
+++ b/packages/read-and-create-calendar-events/client/react/src/App.js
@@ -157,9 +157,9 @@ function Agenda({ serverBaseUrl, userId, calendarId }) {
           const startsAfter = getTodaysDateTimestamp(); // today
           const endsBefore = getSevenDaysFromTodayDateTimestamp(); // 7 days from today
 
-          const url = `${serverBaseUrl}/nylas/read-events?limit=5&startsAfter=${startsAfter}&endsBefore=${endsBefore}${
-            calendarId ? '&calendarId=' + calendarId : ''
-          }`;
+          const queryParams = new URLSearchParams({ limit: 5, startsAfter, endsBefore, calendarId });
+
+          const url = `${serverBaseUrl}/nylas/read-events?${queryParams.toString()}`;
 
           const res = await fetch(url, {
             method: 'GET',

--- a/packages/read-and-create-calendar-events/client/react/src/App.js
+++ b/packages/read-and-create-calendar-events/client/react/src/App.js
@@ -146,13 +146,13 @@ function Agenda({ serverBaseUrl, userId, calendarId }) {
     const getCalendarEvents = async () => {
       if(calendarId) {
         try {
-          const starts_after = null; // applyTimezone(getLocalDateString(new Date(new Date().setDate(new Date().getDate() - 7))));
-          const ends_before = applyTimezone(getLocalDateString(new Date(new Date().setDate(new Date().getDate() + 7))));
+          const startsAfter = null; // applyTimezone(getLocalDateString(new Date(new Date().setDate(new Date().getDate() - 7))));
+          const endsBefore = applyTimezone(getLocalDateString(new Date(new Date().setDate(new Date().getDate() + 7))));
           const limit = 5;
 
           const url = `${serverBaseUrl}/nylas/read-events?${
             calendarId ? 'calendarId=' + calendarId : ''
-          }${starts_after ? '&starts_after=' + starts_after : ''}${ends_before ? '&ends_before=' + ends_before : ''}${limit ? '&limit=' + limit : ''}`;
+          }${startsAfter ? '&startsAfter=' + startsAfter : ''}${endsBefore ? '&endsBefore=' + endsBefore : ''}${limit ? '&limit=' + limit : ''}`;
 
           const res = await fetch(url, {
             method: 'GET',

--- a/packages/read-and-create-calendar-events/client/react/src/utils/date.js
+++ b/packages/read-and-create-calendar-events/client/react/src/utils/date.js
@@ -11,13 +11,9 @@ export const displayMeetingTime = (timestamp) => {
 };
 
 export const getLocalDateString = (date) => {
-  const localDate = date.toLocaleDateString('en-CA', {hour12: false});
-  const localTime = date.toLocaleTimeString('en-CA', {hour12: false});
-  return (
-    localDate +
-    'T' +
-    localTime.split(':').slice(0, 2).join(':')
-  );
+  const localDate = date.toLocaleDateString('en-CA', { hour12: false });
+  const localTime = date.toLocaleTimeString('en-CA', { hour12: false });
+  return localDate + 'T' + localTime.split(':').slice(0, 2).join(':');
 };
 
 export const applyTimezone = (date) => {
@@ -32,7 +28,7 @@ export const getUnixTimestamp = (date) => {
 
 export const getTodaysDateTimestamp = () => {
   const date = new Date();
-  return applyTimezone((getLocalDateString(date)));
+  return applyTimezone(getLocalDateString(date));
 };
 
 export const getSevenDaysFromTodayDateTimestamp = () => {
@@ -51,4 +47,3 @@ export const currentTimePlusHalfHour = () => {
   date.setMinutes(date.getMinutes() + 30);
   return getLocalDateString(date);
 };
-

--- a/packages/read-and-create-calendar-events/client/react/src/utils/date.js
+++ b/packages/read-and-create-calendar-events/client/react/src/utils/date.js
@@ -11,10 +11,11 @@ export const displayMeetingTime = (timestamp) => {
 };
 
 export const getLocalDateString = (date) => {
+  const localDate = date.toLocaleDateString('en-CA', {hour12: false});
   return (
-    date.toLocaleDateString('en-CA') +
+    localDate +
     'T' +
-    date.toLocaleTimeString('en-GB').split(':').slice(0, 2).join(':')
+    localDate.split(':').slice(0, 2).join(':')
   );
 };
 
@@ -22,6 +23,28 @@ export const applyTimezone = (date) => {
   const localizedDate = new Date(date);
 
   return getUnixTimestamp(localizedDate);
+};
+
+export const getTodaysDateTimestamp = () => {
+  const date = new Date();
+  return applyTimezone(getLocalDateString(date));
+};
+
+export const getSevenDaysFromTodayDateTimestamp = () => {
+  const date = new Date();
+  date.setDate(date.getDate() + 7);
+  return applyTimezone(getLocalDateString(date));
+};
+
+export const currentTime = () => {
+  const date = new Date();
+  return getLocalDateString(date);
+};
+
+export const currentTimePlusHalfHour = () => {
+  const date = new Date();
+  date.setMinutes(date.getMinutes() + 30);
+  return getLocalDateString(date);
 };
 
 export const getUnixTimestamp = (date) => {

--- a/packages/read-and-create-calendar-events/client/react/src/utils/date.js
+++ b/packages/read-and-create-calendar-events/client/react/src/utils/date.js
@@ -11,7 +11,11 @@ export const displayMeetingTime = (timestamp) => {
 };
 
 export const getLocalDateString = (date) => {
-  return date.toLocaleDateString("en-CA") + "T" + date.toLocaleTimeString("en-GB").split(":").slice(0, 2).join(":");
+  return (
+    date.toLocaleDateString('en-CA') +
+    'T' +
+    date.toLocaleTimeString('en-GB').split(':').slice(0, 2).join(':')
+  );
 };
 
 export const applyTimezone = (date) => {

--- a/packages/read-and-create-calendar-events/client/react/src/utils/date.js
+++ b/packages/read-and-create-calendar-events/client/react/src/utils/date.js
@@ -12,10 +12,11 @@ export const displayMeetingTime = (timestamp) => {
 
 export const getLocalDateString = (date) => {
   const localDate = date.toLocaleDateString('en-CA', {hour12: false});
+  const localTime = date.toLocaleTimeString('en-CA', {hour12: false});
   return (
     localDate +
     'T' +
-    localDate.split(':').slice(0, 2).join(':')
+    localTime.split(':').slice(0, 2).join(':')
   );
 };
 
@@ -25,15 +26,19 @@ export const applyTimezone = (date) => {
   return getUnixTimestamp(localizedDate);
 };
 
+export const getUnixTimestamp = (date) => {
+  return Math.floor(date.getTime() / 1000);
+};
+
 export const getTodaysDateTimestamp = () => {
   const date = new Date();
-  return applyTimezone(getLocalDateString(date));
+  return applyTimezone((getLocalDateString(date)));
 };
 
 export const getSevenDaysFromTodayDateTimestamp = () => {
   const date = new Date();
   date.setDate(date.getDate() + 7);
-  return applyTimezone(getLocalDateString(date));
+  return applyTimezone(getLocalDateString(new Date(date)));
 };
 
 export const currentTime = () => {
@@ -47,6 +52,3 @@ export const currentTimePlusHalfHour = () => {
   return getLocalDateString(date);
 };
 
-export const getUnixTimestamp = (date) => {
-  return Math.floor(date.getTime() / 1000);
-};

--- a/packages/read-and-create-calendar-events/client/react/src/utils/date.js
+++ b/packages/read-and-create-calendar-events/client/react/src/utils/date.js
@@ -10,8 +10,8 @@ export const displayMeetingTime = (timestamp) => {
   })}`;
 };
 
-export const getDateString = (date) => {
-  return date.toISOString().split(':').slice(0, 2).join(':');
+export const getLocalDateString = (date) => {
+  return date.toLocaleDateString("en-CA") + "T" + date.toLocaleTimeString("en-GB").split(":").slice(0, 2).join(":");
 };
 
 export const applyTimezone = (date) => {

--- a/packages/read-and-create-calendar-events/server/node-express/package.json
+++ b/packages/read-and-create-calendar-events/server/node-express/package.json
@@ -13,10 +13,11 @@
   },
   "dependencies": {
     "body-parser": "^1.15.2",
-    "uuid": "^8.3.2",
+    "cors": "^2.8.5",
+    "dotenv": "^16.0.2",
     "express": "^4.14.0",
     "nylas": "^7.0.0-canary.3",
     "request": "^2.74.0",
-    "cors": "^2.8.5"
+    "uuid": "^8.3.2"
   }
 }

--- a/packages/read-and-create-calendar-events/server/node-express/route.js
+++ b/packages/read-and-create-calendar-events/server/node-express/route.js
@@ -14,7 +14,6 @@ exports.readEvents = async (req, res, nylasClient) => {
   const events = await nylasClient
     .with(user.accessToken)
     .events.list({
-      starts_after: Math.floor(new Date().getTime() / 1000),
       calendar_id: calendarId,
       starts_after: startsAfter,
       ends_before: endsBefore,

--- a/packages/read-and-create-calendar-events/server/node-express/route.js
+++ b/packages/read-and-create-calendar-events/server/node-express/route.js
@@ -10,15 +10,15 @@ exports.readEvents = async (req, res, nylasClient) => {
   if (!user) {
     return res.sendStatus(401);
   }
-  const { calendar_id, starts_after, ends_before, limit } = req.query;
+  const { calendarId, startsAfter, endsBefore, limit } = req.query;
   const events = await nylasClient
     .with(user.accessToken)
     .events.list({
       starts_after: Math.floor(new Date().getTime() / 1000),
       limit: limit || 20,
-      ...(calendar_id && { calendar_id: calendar_id }),
-      ...(starts_after && { starts_after: starts_after }),
-      ...(ends_before && { ends_before: ends_before }),
+      ...(calendarId && { calendar_id: calendarId }),
+      ...(startsAfter && { starts_after: startsAfter }),
+      ...(endsBefore && { ends_before: endsBefore }),
     })
     .then((events) => events);
 

--- a/packages/read-and-create-calendar-events/server/node-express/route.js
+++ b/packages/read-and-create-calendar-events/server/node-express/route.js
@@ -10,13 +10,15 @@ exports.readEvents = async (req, res, nylasClient) => {
   if (!user) {
     return res.sendStatus(401);
   }
-
+  const { calendar_id, starts_after, ends_before, limit } = req.query;
   const events = await nylasClient
     .with(user.accessToken)
     .events.list({
       starts_after: Math.floor(new Date().getTime() / 1000),
-      limit: 20,
-      ...(req.query.calendarId && { calendar_id: req.query.calendarId }),
+      limit: limit || 20,
+      ...(calendar_id && { calendar_id: calendar_id }),
+      ...(starts_after && { starts_after: starts_after }),
+      ...(ends_before && { ends_before: ends_before }),
     })
     .then((events) => events);
 

--- a/packages/read-and-create-calendar-events/server/node-express/route.js
+++ b/packages/read-and-create-calendar-events/server/node-express/route.js
@@ -15,10 +15,10 @@ exports.readEvents = async (req, res, nylasClient) => {
     .with(user.accessToken)
     .events.list({
       starts_after: Math.floor(new Date().getTime() / 1000),
-      limit: limit || 20,
-      ...(calendarId && { calendar_id: calendarId }),
-      ...(startsAfter && { starts_after: startsAfter }),
-      ...(endsBefore && { ends_before: endsBefore }),
+      calendar_id: calendarId,
+      starts_after: startsAfter,
+      ends_before: endsBefore,
+      limit: limit,
     })
     .then((events) => events);
 


### PR DESCRIPTION
# Description
- You should be able to only view calendar events from your primary calendar. 
- The start and end date times should be in your computer’s timezone
- Only your most recent calendar events should be displayed
- Only return top 5 events within a +7 day range

https://nylas.atlassian.net/browse/TEM-120

<img width="1792" alt="image (3)" src="https://user-images.githubusercontent.com/16315004/189411866-910865f4-26f4-4367-aa56-49e0416e182e.png">

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.