### PR TITLE
remove `prettyPrintJSON` dependency from code snippets

### DIFF
--- a/packages/read-and-create-calendar-events/server/node-express/server.js
+++ b/packages/read-and-create-calendar-events/server/node-express/server.js
@@ -2,7 +2,6 @@ const express = require('express');
 const cors = require('cors');
 const dotenv = require('dotenv');
 const { mockDb } = require('./utils/mock-db');
-const { prettyPrintJSON } = require('./utils/formatting');
 const route = require('./route');
 
 const Nylas = require('nylas');
@@ -32,7 +31,7 @@ nylasClient
   .then((applicationDetails) => {
     console.log(
       'Application whitelisted. Application Details: ',
-      prettyPrintJSON(applicationDetails)
+      JSON.stringify(applicationDetails, undefined, 2)
     );
     startExpress();
   });
@@ -77,7 +76,7 @@ const startExpress = () => {
   expressBinding.on(WebhookTriggers.AccountConnected, (payload) => {
     console.log(
       'Webhook trigger received, account connected. Details: ',
-      prettyPrintJSON(payload.objectData)
+      JSON.stringify(payload.objectData, undefined, 2)
     );
   });
 
@@ -85,7 +84,7 @@ const startExpress = () => {
   expressBinding.on(WebhookTriggers.EventCreated, (payload) => {
     console.log(
       'Webhook trigger received, calendar event created. Details: ',
-      prettyPrintJSON(payload.objectData)
+      JSON.stringify(payload.objectData, undefined, 2)
     );
   });
 

--- a/packages/read-and-create-calendar-events/server/node-express/utils/formatting.js
+++ b/packages/read-and-create-calendar-events/server/node-express/utils/formatting.js
@@ -1,6 +1,0 @@
-// Utility function for pretty-printing JSONs :)
-const prettyPrintJSON = (json) => {
-  return JSON.stringify(json, undefined, 2);
-};
-
-module.exports = { prettyPrintJSON };

--- a/packages/read-emails/server/node-express/server.js
+++ b/packages/read-emails/server/node-express/server.js
@@ -4,7 +4,7 @@ const dotenv = require('dotenv');
 const { mockDb } = require('./utils/mock-db');
 
 const Nylas = require('nylas');
-const { WebhookTriggers } = require(' nylas/lib/models/webhook');
+const { WebhookTriggers } = require('nylas/lib/models/webhook');
 const { Scope } = require('nylas/lib/models/connect');
 const { ServerBindings } = require('nylas/lib/config');
 

--- a/packages/read-emails/server/node-express/server.js
+++ b/packages/read-emails/server/node-express/server.js
@@ -2,7 +2,6 @@ const express = require('express');
 const cors = require('cors');
 const dotenv = require('dotenv');
 const { mockDb } = require('./utils/mock-db');
-const { prettyPrintJSON } = require('./utils/formatting');
 
 const Nylas = require('nylas');
 const { WebhookTriggers } = require('nylas/lib/models/webhook');
@@ -31,7 +30,7 @@ nylasClient
   .then((applicationDetails) => {
     console.log(
       'Application whitelisted. Application Details: ',
-      prettyPrintJSON(applicationDetails)
+      JSON.stringify(applicationDetails, undefined, 2)
     );
     startExpress();
   });
@@ -76,7 +75,7 @@ const startExpress = () => {
   expressBinding.on(WebhookTriggers.AccountConnected, (payload) => {
     console.log(
       'Webhook trigger received, account connected. Details: ',
-      prettyPrintJSON(payload.objectData)
+      JSON.stringify(payload.objectData, undefined, 2)
     );
   });
 

--- a/packages/read-emails/server/node-express/server.js
+++ b/packages/read-emails/server/node-express/server.js
@@ -4,7 +4,7 @@ const dotenv = require('dotenv');
 const { mockDb } = require('./utils/mock-db');
 
 const Nylas = require('nylas');
-const { WebhookTriggers } = require('nylas/lib/models/webhook');
+const { WebhookTriggers } = require(' nylas/lib/models/webhook');
 const { Scope } = require('nylas/lib/models/connect');
 const { ServerBindings } = require('nylas/lib/config');
 

--- a/packages/read-emails/server/node-express/utils/formatting.js
+++ b/packages/read-emails/server/node-express/utils/formatting.js
@@ -1,6 +1,0 @@
-// Utility function for pretty-printing JSONs :)
-const prettyPrintJSON = (json) => {
-  return JSON.stringify(json, undefined, 2);
-};
-
-module.exports = { prettyPrintJSON };

--- a/packages/read-emails/server/node/server.js
+++ b/packages/read-emails/server/node/server.js
@@ -1,7 +1,6 @@
 const dotenv = require('dotenv');
 const { mockDb } = require('./utils/mock-db');
 const { mockServer, getReqBody } = require('./utils/mock-server');
-const { prettyPrintJSON } = require('./utils/formatting');
 
 const Nylas = require('nylas');
 const { WebhookTriggers } = require('nylas/lib/models/webhook');
@@ -32,7 +31,7 @@ nylasClient
   .then((applicationDetails) => {
     console.log(
       'Application whitelisted. Application Details: ',
-      prettyPrintJSON(applicationDetails)
+      JSON.stringify(applicationDetails, undefined, 2)
     );
     startServer();
   });
@@ -114,7 +113,7 @@ const startServer = () => {
       case WebhookTriggers.AccountConnected:
         console.log(
           'Webhook trigger received, account connected. Details: ',
-          prettyPrintJSON(delta.objectData)
+          JSON.stringify(delta.objectData, undefined, 2)
         );
         break;
     }

--- a/packages/read-emails/server/node/utils/formatting.js
+++ b/packages/read-emails/server/node/utils/formatting.js
@@ -1,6 +1,0 @@
-// Utility function for pretty-printing JSONs :)
-const prettyPrintJSON = (json) => {
-  return JSON.stringify(json, undefined, 2);
-};
-
-module.exports = { prettyPrintJSON };

--- a/packages/send-and-read-emails/server/node-express/server.js
+++ b/packages/send-and-read-emails/server/node-express/server.js
@@ -2,7 +2,6 @@ const express = require('express');
 const cors = require('cors');
 const dotenv = require('dotenv');
 const { mockDb } = require('./utils/mock-db');
-const { prettyPrintJSON } = require('./utils');
 const route = require('./route');
 
 const Nylas = require('nylas');
@@ -56,7 +55,7 @@ nylasClient
   .then((applicationDetails) => {
     console.log(
       'Application whitelisted. Application Details: ',
-      prettyPrintJSON(applicationDetails)
+      JSON.stringify(applicationDetails, undefined, 2)
     );
     startExpress();
   });
@@ -76,7 +75,7 @@ app.use('/nylas', nylasMiddleware);
 expressBinding.on(WebhookTriggers.AccountConnected, (payload) => {
   console.log(
     'Webhook trigger received, account connected. Details: ',
-    prettyPrintJSON(payload.objectData)
+    JSON.stringify(payload.objectData, undefined, 2)
   );
 });
 
@@ -84,7 +83,7 @@ expressBinding.on(WebhookTriggers.AccountConnected, (payload) => {
 expressBinding.on(WebhookTriggers.MessageCreated, (payload) => {
   console.log(
     'Webhook trigger received, message created. Details: ',
-    prettyPrintJSON(payload.objectData)
+    JSON.stringify(payload.objectData, undefined, 2)
   );
 });
 

--- a/packages/send-and-read-emails/server/node-express/utils/index.js
+++ b/packages/send-and-read-emails/server/node-express/utils/index.js
@@ -1,6 +1,0 @@
-// Utility function for pretty-printing JSONs :)
-function prettyPrintJSON(json) {
-  return JSON.stringify(json, undefined, 2);
-}
-
-module.exports = { prettyPrintJSON };

--- a/packages/send-and-read-emails/server/node/server.js
+++ b/packages/send-and-read-emails/server/node/server.js
@@ -1,7 +1,6 @@
 const dotenv = require('dotenv');
 const { mockDb } = require('./utils/mock-db');
 const { mockServer, getReqBody } = require('./utils/mock-server');
-const { prettyPrintJSON } = require('./utils');
 const route = require('./route');
 
 const Nylas = require('nylas');
@@ -54,7 +53,7 @@ nylasClient
   .then((applicationDetails) => {
     console.log(
       'Application whitelisted. Application Details: ',
-      prettyPrintJSON(applicationDetails)
+      JSON.stringify(applicationDetails, undefined, 2)
     );
     startServer();
   });
@@ -96,7 +95,7 @@ const handleEvent = (delta) => {
     case WebhookTriggers.MessageCreated:
       console.log(
         'Webhook trigger received, message created. Details: ',
-        prettyPrintJSON(delta.objectData)
+        JSON.stringify(delta.objectData, undefined, 2)
       );
       break;
   }

--- a/packages/send-and-read-emails/server/node/utils/index.js
+++ b/packages/send-and-read-emails/server/node/utils/index.js
@@ -1,6 +1,0 @@
-// Utility function for pretty-printing JSONs :)
-function prettyPrintJSON(json) {
-  return JSON.stringify(json, undefined, 2);
-}
-
-module.exports = { prettyPrintJSON };

--- a/packages/send-emails/server/node-express/server.js
+++ b/packages/send-emails/server/node-express/server.js
@@ -2,7 +2,6 @@ const express = require('express');
 const cors = require('cors');
 const dotenv = require('dotenv');
 const { mockDb } = require('./utils/mock-db');
-const { prettyPrintJSON } = require('./utils/formatting');
 
 const Nylas = require('nylas');
 const { WebhookTriggers } = require('nylas/lib/models/webhook');
@@ -32,7 +31,7 @@ nylasClient
   .then((applicationDetails) => {
     console.log(
       'Application whitelisted. Application Details: ',
-      prettyPrintJSON(applicationDetails)
+      JSON.stringify(applicationDetails, undefined, 2)
     );
     startExpress();
   });
@@ -77,7 +76,7 @@ const startExpress = () => {
   expressBinding.on(WebhookTriggers.AccountConnected, (payload) => {
     console.log(
       'Webhook trigger received, account connected. Details: ',
-      prettyPrintJSON(payload.objectData)
+      JSON.stringify(payload.objectData, undefined, 2)
     );
   });
 
@@ -85,7 +84,7 @@ const startExpress = () => {
   expressBinding.on(WebhookTriggers.MessageCreated, (payload) => {
     console.log(
       'Webhook trigger received, message created. Details: ',
-      prettyPrintJSON(payload.objectData)
+      JSON.stringify(payload.objectData, undefined, 2)
     );
   });
 

--- a/packages/send-emails/server/node-express/utils/formatting.js
+++ b/packages/send-emails/server/node-express/utils/formatting.js
@@ -1,6 +1,0 @@
-// Utility function for pretty-printing JSONs :)
-const prettyPrintJSON = (json) => {
-  return JSON.stringify(json, undefined, 2);
-};
-
-module.exports = { prettyPrintJSON };

--- a/packages/send-emails/server/node/server.js
+++ b/packages/send-emails/server/node/server.js
@@ -1,7 +1,6 @@
 const dotenv = require('dotenv');
 const { mockDb } = require('./utils/mock-db');
 const { mockServer, getReqBody } = require('./utils/mock-server');
-const { prettyPrintJSON } = require('./utils/formatting');
 
 const Nylas = require('nylas');
 const { WebhookTriggers } = require('nylas/lib/models/webhook');
@@ -33,7 +32,7 @@ nylasClient
   .then((applicationDetails) => {
     console.log(
       'Application whitelisted. Application Details: ',
-      prettyPrintJSON(applicationDetails)
+      JSON.stringify(applicationDetails, undefined, 2)
     );
     startServer();
   });
@@ -118,7 +117,7 @@ const startServer = () => {
       case WebhookTriggers.MessageCreated:
         console.log(
           'Webhook trigger received, message created. Details: ',
-          prettyPrintJSON(delta.objectData)
+          JSON.stringify(delta.objectData, undefined, 2)
         );
         break;
     }

--- a/packages/send-emails/server/node/utils/formatting.js
+++ b/packages/send-emails/server/node/utils/formatting.js
@@ -1,6 +1,0 @@
-// Utility function for pretty-printing JSONs :)
-const prettyPrintJSON = (json) => {
-  return JSON.stringify(json, undefined, 2);
-};
-
-module.exports = { prettyPrintJSON };


### PR DESCRIPTION
# Description
- replace `prettyPrintJSON(value)` with `JSON.stringify(value, undefined, 2)` in `backend/server.js` for each use-case
- remove `prettyPrintJSON` from `utils` directors

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.