### PR TITLE
Remove handleTokenExchange function and make it inline to avoid context switch

### DIFF
--- a/packages/read-and-create-calendar-events/client/react/src/App.js
+++ b/packages/read-and-create-calendar-events/client/react/src/App.js
@@ -18,15 +18,6 @@ function App() {
 
   const serverBaseUrl = 'http://localhost:9000';
 
-  const handleTokenExchange = (r) => {
-    try {
-      const { id } = JSON.parse(r);
-      setUserId(id);
-    } catch (e) {
-      console.error('An error occurred parsing the response.');
-    }
-  };
-
   useEffect(() => {
     if (!nylas) {
       return;
@@ -34,7 +25,15 @@ function App() {
 
     const params = new URLSearchParams(window.location.search);
     if (params.has('code')) {
-      nylas.exchangeCodeFromUrlForToken().then(handleTokenExchange);
+      nylas
+        .exchangeCodeFromUrlForToken()
+        .then((user) => {
+          const { id } = JSON.parse(user);
+          setUserId(id);
+        })
+        .catch((err) => {
+          console.error('An error occurred parsing the response:', err);
+        });
     }
   }, [nylas]);
 

--- a/packages/read-emails/client/vue/src/App.vue
+++ b/packages/read-emails/client/vue/src/App.vue
@@ -51,9 +51,16 @@ export default {
   created() {
     const params = new URLSearchParams(window.location.search);
     if (params.has('code')) {
-      this.exchangeCodeFromUrlForToken().then((r) =>
-        this.handleTokenExchange(r)
-      );
+      this.exchangeCodeFromUrlForToken()
+        .then((r) => {
+          const user = JSON.parse(r);
+          this.userId = user.id;
+          window.history.replaceState({}, '', `/?userId=${user.id}`);
+        })
+        .catch(() => {
+          console.error('An error occurred parsing the response.');
+          window.history.replaceState({}, '', '/');
+        });
     }
 
     if (params.has('userId')) {
@@ -83,16 +90,6 @@ export default {
     expandEmail(event) {
       const threadId = event.currentTarget.getAttribute('data-thread-id');
       this.openEmails[threadId] = !this.openEmails[threadId];
-    },
-    handleTokenExchange(r) {
-      try {
-        const user = JSON.parse(r);
-        this.userId = user.id;
-        window.history.replaceState({}, '', `/?userId=${user.id}`);
-      } catch (e) {
-        console.error('An error occurred parsing the response.');
-        window.history.replaceState({}, '', '/');
-      }
     },
     async getEmails() {
       try {

--- a/packages/send-emails/client/react/src/App.js
+++ b/packages/send-emails/client/react/src/App.js
@@ -6,15 +6,6 @@ function App() {
   const nylas = useNylas();
   const [userId, setUserId] = useState('');
 
-  const handleTokenExchange = (r) => {
-    try {
-      const { id } = JSON.parse(r);
-      setUserId(id);
-    } catch (e) {
-      console.error('An error occurred parsing the response.');
-    }
-  };
-
   useEffect(() => {
     if (!nylas) {
       return;
@@ -22,7 +13,15 @@ function App() {
 
     const params = new URLSearchParams(window.location.search);
     if (params.has('code')) {
-      nylas.exchangeCodeFromUrlForToken().then(handleTokenExchange);
+      nylas
+        .exchangeCodeFromUrlForToken()
+        .then((user) => {
+          const { id } = JSON.parse(user);
+          setUserId(id);
+        })
+        .catch((err) => {
+          console.error('An error occurred parsing the response:', err);
+        });
     }
   }, [nylas]);
 


### PR DESCRIPTION
# Description
Remove `handleTokenExchange` function and made it inline to avoid context switch for our users so that it is easier to follow as you go through the steps

For templates we need to keep it as simple as possible for our users, so don’t need to have best practices here

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.