### PR TITLE
[read-and-send-email]: Fixed refreshing page after connecting an account results in a loss of connected account info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 .DS_Store
 .env
+datastore.json
 .idea
 .husky/_

--- a/packages/send-and-read-emails/client/react/src/App.js
+++ b/packages/send-and-read-emails/client/react/src/App.js
@@ -25,6 +25,9 @@ function App() {
           console.error('An error occurred parsing the response:', err);
         });
     }
+    if (params.has('userId')) {
+      setUserId(params.get('userId'));
+    }
   }, [nylas]);
 
   useEffect(() => {

--- a/packages/send-and-read-emails/server/node-express/route.js
+++ b/packages/send-and-read-emails/server/node-express/route.js
@@ -1,5 +1,5 @@
 const { default: Draft } = require('nylas/lib/models/draft');
-const { mockDb } = require('./utils/mock-db');
+const mockDb = require('./utils/mock-db');
 
 exports.sendEmail = async (req, res, nylasClient) => {
   if (!req.headers.authorization) {

--- a/packages/send-and-read-emails/server/node-express/server.js
+++ b/packages/send-and-read-emails/server/node-express/server.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const dotenv = require('dotenv');
-const { mockDb } = require('./utils/mock-db');
+const mockDb = require('./utils/mock-db');
 const route = require('./route');
 
 const Nylas = require('nylas');

--- a/packages/send-and-read-emails/server/node-express/utils/mock-db.js
+++ b/packages/send-and-read-emails/server/node-express/utils/mock-db.js
@@ -1,35 +1,87 @@
+const fs = require('fs')
 const { v4: uuidv4 } = require('uuid');
-const users = [];
 
-const mockDb = {
-  findUser: async (id) => {
-    return users.find((u) => u.id === id);
-  },
-  updateUser: async (userId, payload) => {
-    const idx = users.findIndex((u) => u.id === userId);
-    if (idx === -1) {
-      throw new Error('User not found');
+class MockDB {
+    constructor(filename) {
+        if (!filename) {
+            throw new Error('Filename is required');
+        }
+        this.filename = filename
+        try {
+            fs.accessSync(filename, fs.constants.R_OK | fs.constants.W_OK);
+        } catch (err) {
+            fs.writeFileSync(filename, '[]');
+        }
     }
 
-    users[idx] = { ...users[idx], ...payload };
-    return users[idx];
-  },
-  createUser: async (payload) => {
-    const user = {
-      id: uuidv4(),
-      ...payload,
-    };
-    users.push(user);
-    return user;
-  },
-  createOrUpdateUser: async (emailAddress, payload) => {
-    const user = await mockDb.findUser(emailAddress);
-    if (user) {
-      return await mockDb.updateUser(user.id, payload);
-    } else {
-      return await mockDb.createUser(payload);
+    async getJSONRecords() {
+        // Read filecontents of the datastore
+        const jsonRecords = await
+            fs.promises.readFile(this.filename,{
+            encoding : 'utf8'
+        })
+        // Parse JSON records in JavaScript
+        return JSON.parse(jsonRecords);
     }
-  },
-};
+    
+    // Logic to find data
+    async findUser(id, emailAddress) {
+        const jsonRecords = await this.getJSONRecords();
+        return jsonRecords.find((r) => (r.emailAddress === emailAddress 
+            || r.id === id));
+    }
 
-module.exports = { mockDb };
+    // Logic to update data
+    async updateUser(id, payload) {    
+        const jsonRecords = await this.getJSONRecords();
+    
+        const idx = jsonRecords.findIndex((r) => r.id === id);
+        if (idx === -1) {
+            throw new Error('Record not found');
+        }
+    
+        // Update existing record
+        jsonRecords[idx] = { ...jsonRecords[idx], ...payload };
+
+        await fs.promises.writeFile(
+            this.filename,
+            JSON.stringify(jsonRecords, null, 2)  
+        )
+        return jsonRecords[idx];
+    }
+
+    // Logic to add data
+    async createUser(payload) {
+        const jsonRecords = await this.getJSONRecords();
+    
+        const user = {
+            id: uuidv4(),
+            ...payload,
+          };
+        // Adding new record
+        jsonRecords.push(user)
+    
+        // Writing all records back to the file
+        await fs.promises.writeFile(
+            this.filename,
+            JSON.stringify(jsonRecords, null, 2)  
+        )
+    
+        return user;
+    }
+
+    // Logic to add or update data
+    async createOrUpdateUser(id, attributes) {
+        const record = await this.findUser(id, attributes?.emailAddress);
+        if (record) {
+            return await this.updateUser(record.id, attributes);
+        } else {
+            return await this.createUser(attributes);
+        }
+    }
+}
+ 
+const mockDB = new MockDB('datastore.json')
+
+// 'datastore.json' is created at runtime
+module.exports = mockDB

--- a/packages/send-and-read-emails/server/node-express/utils/mock-db.js
+++ b/packages/send-and-read-emails/server/node-express/utils/mock-db.js
@@ -1,87 +1,87 @@
-const fs = require('fs')
+const fs = require('fs');
 const { v4: uuidv4 } = require('uuid');
 
 class MockDB {
-    constructor(filename) {
-        if (!filename) {
-            throw new Error('Filename is required');
-        }
-        this.filename = filename
-        try {
-            fs.accessSync(filename, fs.constants.R_OK | fs.constants.W_OK);
-        } catch (err) {
-            fs.writeFileSync(filename, '[]');
-        }
+  constructor(filename) {
+    if (!filename) {
+      throw new Error('Filename is required');
+    }
+    this.filename = filename;
+    try {
+      fs.accessSync(filename, fs.constants.R_OK | fs.constants.W_OK);
+    } catch (err) {
+      fs.writeFileSync(filename, '[]');
+    }
+  }
+
+  async getJSONRecords() {
+    // Read filecontents of the datastore
+    const jsonRecords = await fs.promises.readFile(this.filename, {
+      encoding: 'utf8',
+    });
+    // Parse JSON records in JavaScript
+    return JSON.parse(jsonRecords);
+  }
+
+  // Logic to find data
+  async findUser(id, emailAddress) {
+    const jsonRecords = await this.getJSONRecords();
+    return jsonRecords.find(
+      (r) => r.emailAddress === emailAddress || r.id === id
+    );
+  }
+
+  // Logic to update data
+  async updateUser(id, payload) {
+    const jsonRecords = await this.getJSONRecords();
+
+    const idx = jsonRecords.findIndex((r) => r.id === id);
+    if (idx === -1) {
+      throw new Error('Record not found');
     }
 
-    async getJSONRecords() {
-        // Read filecontents of the datastore
-        const jsonRecords = await
-            fs.promises.readFile(this.filename,{
-            encoding : 'utf8'
-        })
-        // Parse JSON records in JavaScript
-        return JSON.parse(jsonRecords);
-    }
-    
-    // Logic to find data
-    async findUser(id, emailAddress) {
-        const jsonRecords = await this.getJSONRecords();
-        return jsonRecords.find((r) => (r.emailAddress === emailAddress 
-            || r.id === id));
-    }
+    // Update existing record
+    jsonRecords[idx] = { ...jsonRecords[idx], ...payload };
 
-    // Logic to update data
-    async updateUser(id, payload) {    
-        const jsonRecords = await this.getJSONRecords();
-    
-        const idx = jsonRecords.findIndex((r) => r.id === id);
-        if (idx === -1) {
-            throw new Error('Record not found');
-        }
-    
-        // Update existing record
-        jsonRecords[idx] = { ...jsonRecords[idx], ...payload };
+    await fs.promises.writeFile(
+      this.filename,
+      JSON.stringify(jsonRecords, null, 2)
+    );
+    return jsonRecords[idx];
+  }
 
-        await fs.promises.writeFile(
-            this.filename,
-            JSON.stringify(jsonRecords, null, 2)  
-        )
-        return jsonRecords[idx];
-    }
+  // Logic to add data
+  async createUser(payload) {
+    const jsonRecords = await this.getJSONRecords();
 
-    // Logic to add data
-    async createUser(payload) {
-        const jsonRecords = await this.getJSONRecords();
-    
-        const user = {
-            id: uuidv4(),
-            ...payload,
-          };
-        // Adding new record
-        jsonRecords.push(user)
-    
-        // Writing all records back to the file
-        await fs.promises.writeFile(
-            this.filename,
-            JSON.stringify(jsonRecords, null, 2)  
-        )
-    
-        return user;
-    }
+    const user = {
+      id: uuidv4(),
+      ...payload,
+    };
+    // Adding new record
+    jsonRecords.push(user);
 
-    // Logic to add or update data
-    async createOrUpdateUser(id, attributes) {
-        const record = await this.findUser(id, attributes?.emailAddress);
-        if (record) {
-            return await this.updateUser(record.id, attributes);
-        } else {
-            return await this.createUser(attributes);
-        }
+    // Writing all records back to the file
+    await fs.promises.writeFile(
+      this.filename,
+      JSON.stringify(jsonRecords, null, 2)
+    );
+
+    return user;
+  }
+
+  // Logic to add or update data
+  async createOrUpdateUser(id, attributes) {
+    const record = await this.findUser(id, attributes?.emailAddress);
+    if (record) {
+      return await this.updateUser(record.id, attributes);
+    } else {
+      return await this.createUser(attributes);
     }
+  }
 }
- 
-const mockDB = new MockDB('datastore.json')
+
+const mockDB = new MockDB('datastore.json');
 
 // 'datastore.json' is created at runtime
-module.exports = mockDB
+module.exports = mockDB;

--- a/packages/send-and-read-emails/server/node/route.js
+++ b/packages/send-and-read-emails/server/node/route.js
@@ -1,5 +1,5 @@
 const { default: Draft } = require('nylas/lib/models/draft');
-const { mockDb } = require('./utils/mock-db');
+const mockDb = require('./utils/mock-db');
 const { getReqBody } = require('./utils/mock-server');
 
 exports.sendEmail = async (req, res, nylasClient) => {

--- a/packages/send-and-read-emails/server/node/server.js
+++ b/packages/send-and-read-emails/server/node/server.js
@@ -1,5 +1,5 @@
 const dotenv = require('dotenv');
-const { mockDb } = require('./utils/mock-db');
+const mockDb = require('./utils/mock-db');
 const { mockServer, getReqBody } = require('./utils/mock-server');
 const route = require('./route');
 

--- a/packages/send-and-read-emails/server/node/utils/mock-db.js
+++ b/packages/send-and-read-emails/server/node/utils/mock-db.js
@@ -1,35 +1,87 @@
+const fs = require('fs')
 const { v4: uuidv4 } = require('uuid');
-const users = [];
 
-const mockDb = {
-  findUser: async (id) => {
-    return users.find((u) => u.id === id);
-  },
-  updateUser: async (userId, payload) => {
-    const idx = users.findIndex((u) => u.id === userId);
-    if (idx === -1) {
-      throw new Error('User not found');
+class MockDB {
+    constructor(filename) {
+        if (!filename) {
+            throw new Error('Filename is required');
+        }
+        this.filename = filename
+        try {
+            fs.accessSync(filename, fs.constants.R_OK | fs.constants.W_OK);
+        } catch (err) {
+            fs.writeFileSync(filename, '[]');
+        }
     }
 
-    users[idx] = { ...users[idx], ...payload };
-    return users[idx];
-  },
-  createUser: async (payload) => {
-    const user = {
-      id: uuidv4(),
-      ...payload,
-    };
-    users.push(user);
-    return user;
-  },
-  createOrUpdateUser: async (emailAddress, payload) => {
-    const user = await mockDb.findUser(emailAddress);
-    if (user) {
-      return await mockDb.updateUser(user.id, payload);
-    } else {
-      return await mockDb.createUser(payload);
+    async getJSONRecords() {
+        // Read filecontents of the datastore
+        const jsonRecords = await
+            fs.promises.readFile(this.filename,{
+            encoding : 'utf8'
+        })
+        // Parse JSON records in JavaScript
+        return JSON.parse(jsonRecords);
     }
-  },
-};
+    
+    // Logic to find data
+    async findUser(id, emailAddress) {
+        const jsonRecords = await this.getJSONRecords();
+        return jsonRecords.find((r) => (r.emailAddress === emailAddress 
+            || r.id === id));
+    }
 
-module.exports = { mockDb };
+    // Logic to update data
+    async updateUser(id, payload) {    
+        const jsonRecords = await this.getJSONRecords();
+    
+        const idx = jsonRecords.findIndex((r) => r.id === id);
+        if (idx === -1) {
+            throw new Error('Record not found');
+        }
+    
+        // Update existing record
+        jsonRecords[idx] = { ...jsonRecords[idx], ...payload };
+
+        await fs.promises.writeFile(
+            this.filename,
+            JSON.stringify(jsonRecords, null, 2)  
+        )
+        return jsonRecords[idx];
+    }
+
+    // Logic to add data
+    async createUser(payload) {
+        const jsonRecords = await this.getJSONRecords();
+    
+        const user = {
+            id: uuidv4(),
+            ...payload,
+          };
+        // Adding new record
+        jsonRecords.push(user)
+    
+        // Writing all records back to the file
+        await fs.promises.writeFile(
+            this.filename,
+            JSON.stringify(jsonRecords, null, 2)  
+        )
+    
+        return user;
+    }
+
+    // Logic to add or update data
+    async createOrUpdateUser(id, attributes) {
+        const record = await this.findUser(id, attributes?.emailAddress);
+        if (record) {
+            return await this.updateUser(record.id, attributes);
+        } else {
+            return await this.createUser(attributes);
+        }
+    }
+}
+ 
+const mockDB = new MockDB('datastore.json')
+
+// 'datastore.json' is created at runtime
+module.exports = mockDB

--- a/packages/send-and-read-emails/server/node/utils/mock-db.js
+++ b/packages/send-and-read-emails/server/node/utils/mock-db.js
@@ -1,87 +1,87 @@
-const fs = require('fs')
+const fs = require('fs');
 const { v4: uuidv4 } = require('uuid');
 
 class MockDB {
-    constructor(filename) {
-        if (!filename) {
-            throw new Error('Filename is required');
-        }
-        this.filename = filename
-        try {
-            fs.accessSync(filename, fs.constants.R_OK | fs.constants.W_OK);
-        } catch (err) {
-            fs.writeFileSync(filename, '[]');
-        }
+  constructor(filename) {
+    if (!filename) {
+      throw new Error('Filename is required');
+    }
+    this.filename = filename;
+    try {
+      fs.accessSync(filename, fs.constants.R_OK | fs.constants.W_OK);
+    } catch (err) {
+      fs.writeFileSync(filename, '[]');
+    }
+  }
+
+  async getJSONRecords() {
+    // Read filecontents of the datastore
+    const jsonRecords = await fs.promises.readFile(this.filename, {
+      encoding: 'utf8',
+    });
+    // Parse JSON records in JavaScript
+    return JSON.parse(jsonRecords);
+  }
+
+  // Logic to find data
+  async findUser(id, emailAddress) {
+    const jsonRecords = await this.getJSONRecords();
+    return jsonRecords.find(
+      (r) => r.emailAddress === emailAddress || r.id === id
+    );
+  }
+
+  // Logic to update data
+  async updateUser(id, payload) {
+    const jsonRecords = await this.getJSONRecords();
+
+    const idx = jsonRecords.findIndex((r) => r.id === id);
+    if (idx === -1) {
+      throw new Error('Record not found');
     }
 
-    async getJSONRecords() {
-        // Read filecontents of the datastore
-        const jsonRecords = await
-            fs.promises.readFile(this.filename,{
-            encoding : 'utf8'
-        })
-        // Parse JSON records in JavaScript
-        return JSON.parse(jsonRecords);
-    }
-    
-    // Logic to find data
-    async findUser(id, emailAddress) {
-        const jsonRecords = await this.getJSONRecords();
-        return jsonRecords.find((r) => (r.emailAddress === emailAddress 
-            || r.id === id));
-    }
+    // Update existing record
+    jsonRecords[idx] = { ...jsonRecords[idx], ...payload };
 
-    // Logic to update data
-    async updateUser(id, payload) {    
-        const jsonRecords = await this.getJSONRecords();
-    
-        const idx = jsonRecords.findIndex((r) => r.id === id);
-        if (idx === -1) {
-            throw new Error('Record not found');
-        }
-    
-        // Update existing record
-        jsonRecords[idx] = { ...jsonRecords[idx], ...payload };
+    await fs.promises.writeFile(
+      this.filename,
+      JSON.stringify(jsonRecords, null, 2)
+    );
+    return jsonRecords[idx];
+  }
 
-        await fs.promises.writeFile(
-            this.filename,
-            JSON.stringify(jsonRecords, null, 2)  
-        )
-        return jsonRecords[idx];
-    }
+  // Logic to add data
+  async createUser(payload) {
+    const jsonRecords = await this.getJSONRecords();
 
-    // Logic to add data
-    async createUser(payload) {
-        const jsonRecords = await this.getJSONRecords();
-    
-        const user = {
-            id: uuidv4(),
-            ...payload,
-          };
-        // Adding new record
-        jsonRecords.push(user)
-    
-        // Writing all records back to the file
-        await fs.promises.writeFile(
-            this.filename,
-            JSON.stringify(jsonRecords, null, 2)  
-        )
-    
-        return user;
-    }
+    const user = {
+      id: uuidv4(),
+      ...payload,
+    };
+    // Adding new record
+    jsonRecords.push(user);
 
-    // Logic to add or update data
-    async createOrUpdateUser(id, attributes) {
-        const record = await this.findUser(id, attributes?.emailAddress);
-        if (record) {
-            return await this.updateUser(record.id, attributes);
-        } else {
-            return await this.createUser(attributes);
-        }
+    // Writing all records back to the file
+    await fs.promises.writeFile(
+      this.filename,
+      JSON.stringify(jsonRecords, null, 2)
+    );
+
+    return user;
+  }
+
+  // Logic to add or update data
+  async createOrUpdateUser(id, attributes) {
+    const record = await this.findUser(id, attributes?.emailAddress);
+    if (record) {
+      return await this.updateUser(record.id, attributes);
+    } else {
+      return await this.createUser(attributes);
     }
+  }
 }
- 
-const mockDB = new MockDB('datastore.json')
+
+const mockDB = new MockDB('datastore.json');
 
 // 'datastore.json' is created at runtime
-module.exports = mockDB
+module.exports = mockDB;


### PR DESCRIPTION
# Description
- Fixed the issue where refreshing the store resulted in loss of connected account
- Added a local file db system to replace existing mock db which stores the account info locally

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.