### PR TITLE
[read-emails]: Fix refreshing page losing connected account info

### DIFF
--- a/packages/read-emails/client/react/src/App.js
+++ b/packages/read-emails/client/react/src/App.js
@@ -24,7 +24,18 @@ function App() {
           console.error('An error occurred parsing the response:', error);
         });
     }
+    if (params.has('userId')) {
+      setUserId(params.get('userId'));
+    }
   }, [nylas]);
+
+  useEffect(() => {
+    if (userId.length) {
+      window.history.replaceState({}, '', `/?userId=${userId}`);
+    } else {
+      window.history.replaceState({}, '', '/');
+    }
+  }, [userId]);
 
   return !userId ? (
     <NylasLogin />

--- a/packages/read-emails/server/node-express/server.js
+++ b/packages/read-emails/server/node-express/server.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const dotenv = require('dotenv');
-const { mockDb } = require('./utils/mock-db');
+const mockDb = require('./utils/mock-db');
 
 const Nylas = require('nylas');
 const { WebhookTriggers } = require('nylas/lib/models/webhook');

--- a/packages/read-emails/server/node-express/utils/mock-db.js
+++ b/packages/read-emails/server/node-express/utils/mock-db.js
@@ -1,35 +1,87 @@
+const fs = require('fs');
 const { v4: uuidv4 } = require('uuid');
-const users = [];
 
-const mockDb = {
-  findUser: async (id) => {
-    return users.find((u) => u.id === id);
-  },
-  updateUser: async (userId, payload) => {
-    const idx = users.findIndex((u) => u.id === userId);
+class MockDB {
+  constructor(filename) {
+    if (!filename) {
+      throw new Error('Filename is required');
+    }
+    this.filename = filename;
+    try {
+      fs.accessSync(filename, fs.constants.R_OK | fs.constants.W_OK);
+    } catch (err) {
+      fs.writeFileSync(filename, '[]');
+    }
+  }
+
+  async getJSONRecords() {
+    // Read filecontents of the datastore
+    const jsonRecords = await fs.promises.readFile(this.filename, {
+      encoding: 'utf8',
+    });
+    // Parse JSON records in JavaScript
+    return JSON.parse(jsonRecords);
+  }
+
+  // Logic to find data
+  async findUser(id, emailAddress) {
+    const jsonRecords = await this.getJSONRecords();
+    return jsonRecords.find(
+      (r) => r.emailAddress === emailAddress || r.id === id
+    );
+  }
+
+  // Logic to update data
+  async updateUser(id, payload) {
+    const jsonRecords = await this.getJSONRecords();
+
+    const idx = jsonRecords.findIndex((r) => r.id === id);
     if (idx === -1) {
-      throw new Error('User not found');
+      throw new Error('Record not found');
     }
 
-    users[idx] = { ...users[idx], ...payload };
-    return users[idx];
-  },
-  createUser: async (payload) => {
+    // Update existing record
+    jsonRecords[idx] = { ...jsonRecords[idx], ...payload };
+
+    await fs.promises.writeFile(
+      this.filename,
+      JSON.stringify(jsonRecords, null, 2)
+    );
+    return jsonRecords[idx];
+  }
+
+  // Logic to add data
+  async createUser(payload) {
+    const jsonRecords = await this.getJSONRecords();
+
     const user = {
       id: uuidv4(),
       ...payload,
     };
-    users.push(user);
-    return user;
-  },
-  createOrUpdateUser: async (emailAddress, payload) => {
-    const user = await mockDb.findUser(emailAddress);
-    if (user) {
-      return await mockDb.updateUser(user.id, payload);
-    } else {
-      return await mockDb.createUser(payload);
-    }
-  },
-};
+    // Adding new record
+    jsonRecords.push(user);
 
-module.exports = { mockDb };
+    // Writing all records back to the file
+    await fs.promises.writeFile(
+      this.filename,
+      JSON.stringify(jsonRecords, null, 2)
+    );
+
+    return user;
+  }
+
+  // Logic to add or update data
+  async createOrUpdateUser(id, attributes) {
+    const record = await this.findUser(id, attributes?.emailAddress);
+    if (record) {
+      return await this.updateUser(record.id, attributes);
+    } else {
+      return await this.createUser(attributes);
+    }
+  }
+}
+
+const mockDB = new MockDB('datastore.json');
+
+// 'datastore.json' is created at runtime
+module.exports = mockDB;

--- a/packages/read-emails/server/node/server.js
+++ b/packages/read-emails/server/node/server.js
@@ -1,5 +1,5 @@
 const dotenv = require('dotenv');
-const { mockDb } = require('./utils/mock-db');
+const mockDb = require('./utils/mock-db');
 const { mockServer, getReqBody } = require('./utils/mock-server');
 
 const Nylas = require('nylas');

--- a/packages/read-emails/server/node/utils/mock-db.js
+++ b/packages/read-emails/server/node/utils/mock-db.js
@@ -1,35 +1,87 @@
+const fs = require('fs');
 const { v4: uuidv4 } = require('uuid');
-const users = [];
 
-const mockDb = {
-  findUser: async (id) => {
-    return users.find((u) => u.id === id);
-  },
-  updateUser: async (userId, payload) => {
-    const idx = users.findIndex((u) => u.id === userId);
+class MockDB {
+  constructor(filename) {
+    if (!filename) {
+      throw new Error('Filename is required');
+    }
+    this.filename = filename;
+    try {
+      fs.accessSync(filename, fs.constants.R_OK | fs.constants.W_OK);
+    } catch (err) {
+      fs.writeFileSync(filename, '[]');
+    }
+  }
+
+  async getJSONRecords() {
+    // Read filecontents of the datastore
+    const jsonRecords = await fs.promises.readFile(this.filename, {
+      encoding: 'utf8',
+    });
+    // Parse JSON records in JavaScript
+    return JSON.parse(jsonRecords);
+  }
+
+  // Logic to find data
+  async findUser(id, emailAddress) {
+    const jsonRecords = await this.getJSONRecords();
+    return jsonRecords.find(
+      (r) => r.emailAddress === emailAddress || r.id === id
+    );
+  }
+
+  // Logic to update data
+  async updateUser(id, payload) {
+    const jsonRecords = await this.getJSONRecords();
+
+    const idx = jsonRecords.findIndex((r) => r.id === id);
     if (idx === -1) {
-      throw new Error('User not found');
+      throw new Error('Record not found');
     }
 
-    users[idx] = { ...users[idx], ...payload };
-    return users[idx];
-  },
-  createUser: async (payload) => {
+    // Update existing record
+    jsonRecords[idx] = { ...jsonRecords[idx], ...payload };
+
+    await fs.promises.writeFile(
+      this.filename,
+      JSON.stringify(jsonRecords, null, 2)
+    );
+    return jsonRecords[idx];
+  }
+
+  // Logic to add data
+  async createUser(payload) {
+    const jsonRecords = await this.getJSONRecords();
+
     const user = {
       id: uuidv4(),
       ...payload,
     };
-    users.push(user);
-    return user;
-  },
-  createOrUpdateUser: async (emailAddress, payload) => {
-    const user = await mockDb.findUser(emailAddress);
-    if (user) {
-      return await mockDb.updateUser(user.id, payload);
-    } else {
-      return await mockDb.createUser(payload);
-    }
-  },
-};
+    // Adding new record
+    jsonRecords.push(user);
 
-module.exports = { mockDb };
+    // Writing all records back to the file
+    await fs.promises.writeFile(
+      this.filename,
+      JSON.stringify(jsonRecords, null, 2)
+    );
+
+    return user;
+  }
+
+  // Logic to add or update data
+  async createOrUpdateUser(id, attributes) {
+    const record = await this.findUser(id, attributes?.emailAddress);
+    if (record) {
+      return await this.updateUser(record.id, attributes);
+    } else {
+      return await this.createUser(attributes);
+    }
+  }
+}
+
+const mockDB = new MockDB('datastore.json');
+
+// 'datastore.json' is created at runtime
+module.exports = mockDB;


### PR DESCRIPTION
# Description
- Fixed the issue where refreshing the store resulted in loss of connected account
- Added a local file db system to replace existing mock db which stores the account info locally

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.