### PR TITLE
[read emails] regression - Double webhook events when connecting an account

### DIFF
--- a/packages/read-emails/frontend/react/src/App.jsx
+++ b/packages/read-emails/frontend/react/src/App.jsx
@@ -13,7 +13,7 @@ function App() {
 
     // Handle the code that is passed in the query params from Nylas after a successful login
     const params = new URLSearchParams(window.location.search);
-    if (params.has('code')) {
+    if (params.has('code') && !userId) {
       nylas
         .exchangeCodeFromUrlForToken()
         .then((user) => {

--- a/packages/read-emails/frontend/react/src/App.jsx
+++ b/packages/read-emails/frontend/react/src/App.jsx
@@ -13,7 +13,7 @@ function App() {
 
     // Handle the code that is passed in the query params from Nylas after a successful login
     const params = new URLSearchParams(window.location.search);
-    if (params.has('code') && !userId) {
+    if (params.has('code')) {
       nylas
         .exchangeCodeFromUrlForToken()
         .then((user) => {
@@ -23,9 +23,6 @@ function App() {
         .catch((error) => {
           console.error('An error occurred parsing the response:', error);
         });
-    }
-    if (params.has('userId')) {
-      setUserId(params.get('userId'));
     }
   }, [nylas]);
 


### PR DESCRIPTION
# Description

- Added a check for `userId` being  falsey, so `exchangeCodeFromUrlForToken()` isn't called twice


# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.