### PR TITLE
[all use-cases] remove `/nylas` from nylasMiddleware registration

### DIFF
--- a/packages/read-and-create-calendar-events/server/node-express/server.js
+++ b/packages/read-and-create-calendar-events/server/node-express/server.js
@@ -57,7 +57,7 @@ const expressBinding = new ServerBindings.express(nylasClient, {
 
 // Mount the express middleware to your express app
 const nylasMiddleware = expressBinding.buildMiddleware();
-app.use('/nylas', nylasMiddleware);
+app.use(nylasMiddleware);
 
 // Handle when an account gets connected
 expressBinding.on(WebhookTriggers.AccountConnected, (payload) => {

--- a/packages/read-emails/server/node-express/server.js
+++ b/packages/read-emails/server/node-express/server.js
@@ -56,7 +56,7 @@ const expressBinding = new ServerBindings.express(nylasClient, {
 
 // Mount the express middleware to your express app
 const nylasMiddleware = expressBinding.buildMiddleware();
-app.use('/nylas', nylasMiddleware);
+app.use(nylasMiddleware);
 
 // Handle when an account gets connected
 expressBinding.on(WebhookTriggers.AccountConnected, (payload) => {

--- a/packages/send-and-read-emails/server/node-express/server.js
+++ b/packages/send-and-read-emails/server/node-express/server.js
@@ -57,7 +57,7 @@ const expressBinding = new ServerBindings.express(nylasClient, {
 
 // Mount the express middleware to your express app
 const nylasMiddleware = expressBinding.buildMiddleware();
-app.use('/nylas', nylasMiddleware);
+app.use(nylasMiddleware);
 
 // Handle when an account gets connected
 expressBinding.on(WebhookTriggers.AccountConnected, (payload) => {

--- a/packages/send-emails/server/node-express/server.js
+++ b/packages/send-emails/server/node-express/server.js
@@ -58,7 +58,7 @@ const expressBinding = new ServerBindings.express(nylasClient, {
 
 // Mount the express middleware to your express app
 const nylasMiddleware = expressBinding.buildMiddleware();
-app.use('/nylas', nylasMiddleware);
+app.use(nylasMiddleware);
 
 // Handle when an account gets connected
 expressBinding.on(WebhookTriggers.AccountConnected, (payload) => {


### PR DESCRIPTION
# Description:
The middleware for all use cases are being registered as `/nylas/nylas/*` and causing an error

# What you did:
- remove `/nylas` as mount point for `nylasMiddleware`

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.