### PR TITLE
[all use-cases] update middleware an environment variable for local client server URI

### DIFF
--- a/packages/read-and-create-calendar-events/backend/node-express/server.js
+++ b/packages/read-and-create-calendar-events/backend/node-express/server.js
@@ -27,7 +27,7 @@ app.use(cors());
 
 // The uri for the frontend
 const CLIENT_URI =
-  process.env.REACT_APP_API || `http://localhost:${process.env.PORT || 3000}`;
+  process.env.CLIENT_URI || `http://localhost:${process.env.PORT || 3000}`;
 
 // Use the express bindings provided by the SDK and pass in additional
 // configuration such as auth scopes

--- a/packages/read-and-create-calendar-events/backend/node-express/server.js
+++ b/packages/read-and-create-calendar-events/backend/node-express/server.js
@@ -26,7 +26,8 @@ const app = express();
 app.use(cors());
 
 // The uri for the frontend
-const CLIENT_URI = `http://localhost:${process.env.PORT || 3000}`;
+const CLIENT_URI =
+  process.env.REACT_APP_API || `http://localhost:${process.env.PORT || 3000}`;
 
 // Use the express bindings provided by the SDK and pass in additional
 // configuration such as auth scopes

--- a/packages/read-emails/backend/node-express/package-lock.json
+++ b/packages/read-emails/backend/node-express/package-lock.json
@@ -12,7 +12,7 @@
         "body-parser": "^1.15.2",
         "cors": "^2.8.5",
         "express": "^4.14.0",
-        "nylas": "^7.0.0-canary.3",
+        "nylas": "7.0.0-beta.0",
         "request": "^2.74.0",
         "uuid": "^8.3.2"
       }
@@ -781,9 +781,9 @@
       }
     },
     "node_modules/nylas": {
-      "version": "7.0.0-canary.3",
-      "resolved": "https://registry.npmjs.org/nylas/-/nylas-7.0.0-canary.3.tgz",
-      "integrity": "sha512-kBc9SYuqHZBZwALZbvcty5GxbFZP+cPoHYkIdFCfC1iJjCMP5bI7qqkNMvOvOVKhLsqHI2JGICDGGVVfYhrnHw==",
+      "version": "7.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/nylas/-/nylas-7.0.0-beta.0.tgz",
+      "integrity": "sha512-WxYAMVMz+CmBWD47Jrkv73PzyXbJep2DuXAHH2gP3y12ykdbU+dyHf9Lrj95f0bP8ZBdLD0IDLzqJoKfEvxdqw==",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "backoff": "^2.5.0",
@@ -1861,9 +1861,9 @@
       "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ=="
     },
     "nylas": {
-      "version": "7.0.0-canary.3",
-      "resolved": "https://registry.npmjs.org/nylas/-/nylas-7.0.0-canary.3.tgz",
-      "integrity": "sha512-kBc9SYuqHZBZwALZbvcty5GxbFZP+cPoHYkIdFCfC1iJjCMP5bI7qqkNMvOvOVKhLsqHI2JGICDGGVVfYhrnHw==",
+      "version": "7.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/nylas/-/nylas-7.0.0-beta.0.tgz",
+      "integrity": "sha512-WxYAMVMz+CmBWD47Jrkv73PzyXbJep2DuXAHH2gP3y12ykdbU+dyHf9Lrj95f0bP8ZBdLD0IDLzqJoKfEvxdqw==",
       "requires": {
         "abort-controller": "^3.0.0",
         "backoff": "^2.5.0",

--- a/packages/read-emails/backend/node-express/server.js
+++ b/packages/read-emails/backend/node-express/server.js
@@ -26,7 +26,7 @@ const nylasClient = new Nylas({
 
 // The uri for the frontend
 const CLIENT_URI =
-  process.env.REACT_APP_API || `http://localhost:${process.env.PORT || 3000}`;
+  process.env.CLIENT_URI || `http://localhost:${process.env.PORT || 3000}`;
 
 // Use the express bindings provided by the SDK and pass in
 // additional configuration such as auth scopes

--- a/packages/read-emails/backend/node-express/server.js
+++ b/packages/read-emails/backend/node-express/server.js
@@ -25,7 +25,8 @@ const nylasClient = new Nylas({
 });
 
 // The uri for the frontend
-const CLIENT_URI = `http://localhost:${process.env.PORT || 3000}`;
+const CLIENT_URI =
+  process.env.REACT_APP_API || `http://localhost:${process.env.PORT || 3000}`;
 
 // Use the express bindings provided by the SDK and pass in
 // additional configuration such as auth scopes

--- a/packages/read-emails/backend/node/server.js
+++ b/packages/read-emails/backend/node/server.js
@@ -21,7 +21,8 @@ const nylasClient = new Nylas({
 });
 
 // The uri for the frontend
-const CLIENT_URI = `http://localhost:${process.env.PORT || 3000}`;
+const CLIENT_URI =
+  process.env.REACT_APP_API || `http://localhost:${process.env.PORT || 3000}`;
 
 // Use the routes provided by the Nylas Node SDK to quickly implement
 // the authentication flow

--- a/packages/read-emails/backend/node/server.js
+++ b/packages/read-emails/backend/node/server.js
@@ -22,7 +22,7 @@ const nylasClient = new Nylas({
 
 // The uri for the frontend
 const CLIENT_URI =
-  process.env.REACT_APP_API || `http://localhost:${process.env.PORT || 3000}`;
+  process.env.CLIENT_URI || `http://localhost:${process.env.PORT || 3000}`;
 
 // Use the routes provided by the Nylas Node SDK to quickly implement
 // the authentication flow

--- a/packages/send-and-read-emails/backend/node-express/server.js
+++ b/packages/send-and-read-emails/backend/node-express/server.js
@@ -27,7 +27,7 @@ app.use(cors());
 
 // The uri for the frontend
 const CLIENT_URI =
-  process.env.REACT_APP_API || `http://localhost:${process.env.PORT || 3000}`;
+  process.env.CLIENT_URI || `http://localhost:${process.env.PORT || 3000}`;
 
 // Use the express bindings provided by the SDK and pass in additional
 // configuration such as auth scopes

--- a/packages/send-and-read-emails/backend/node-express/server.js
+++ b/packages/send-and-read-emails/backend/node-express/server.js
@@ -26,7 +26,8 @@ const app = express();
 app.use(cors());
 
 // The uri for the frontend
-const CLIENT_URI = `http://localhost:${process.env.PORT || 3000}`;
+const CLIENT_URI =
+  process.env.REACT_APP_API || `http://localhost:${process.env.PORT || 3000}`;
 
 // Use the express bindings provided by the SDK and pass in additional
 // configuration such as auth scopes

--- a/packages/send-and-read-emails/backend/node/server.js
+++ b/packages/send-and-read-emails/backend/node/server.js
@@ -23,7 +23,7 @@ const nylasClient = new Nylas({
 
 // The uri for the frontend
 const CLIENT_URI =
-  process.env.REACT_APP_API || `http://localhost:${process.env.PORT || 3000}`;
+  process.env.CLIENT_URI || `http://localhost:${process.env.PORT || 3000}`;
 
 // Use the routes provided by the Nylas Node SDK to quickly implement
 // the authentication flow

--- a/packages/send-and-read-emails/backend/node/server.js
+++ b/packages/send-and-read-emails/backend/node/server.js
@@ -22,7 +22,8 @@ const nylasClient = new Nylas({
 });
 
 // The uri for the frontend
-const CLIENT_URI = `http://localhost:${process.env.PORT || 3000}`;
+const CLIENT_URI =
+  process.env.REACT_APP_API || `http://localhost:${process.env.PORT || 3000}`;
 
 // Use the routes provided by the Nylas Node SDK to quickly implement
 // the authentication flow

--- a/packages/send-emails/backend/node-express/server.js
+++ b/packages/send-emails/backend/node-express/server.js
@@ -27,7 +27,7 @@ const nylasClient = new Nylas({
 
 // The uri for the frontend
 const CLIENT_URI =
-  process.env.REACT_APP_API || `http://localhost:${process.env.PORT || 3000}`;
+  process.env.CLIENT_URI || `http://localhost:${process.env.PORT || 3000}`;
 
 // Use the express bindings provided by the SDK and pass in additional
 // configuration such as auth scopes

--- a/packages/send-emails/backend/node-express/server.js
+++ b/packages/send-emails/backend/node-express/server.js
@@ -26,7 +26,8 @@ const nylasClient = new Nylas({
 });
 
 // The uri for the frontend
-const CLIENT_URI = `http://localhost:${process.env.PORT || 3000}`;
+const CLIENT_URI =
+  process.env.REACT_APP_API || `http://localhost:${process.env.PORT || 3000}`;
 
 // Use the express bindings provided by the SDK and pass in additional
 // configuration such as auth scopes

--- a/packages/send-emails/backend/node/server.js
+++ b/packages/send-emails/backend/node/server.js
@@ -23,7 +23,7 @@ const nylasClient = new Nylas({
 
 // The uri for the frontend
 const CLIENT_URI =
-  process.env.REACT_APP_API || `http://localhost:${process.env.PORT || 3000}`;
+  process.env.CLIENT_URI || `http://localhost:${process.env.PORT || 3000}`;
 
 // Use the routes provided by the Nylas Node SDK to quickly implement
 // the authentication flow

--- a/packages/send-emails/backend/node/server.js
+++ b/packages/send-emails/backend/node/server.js
@@ -22,7 +22,8 @@ const nylasClient = new Nylas({
 });
 
 // The uri for the frontend
-const CLIENT_URI = `http://localhost:${process.env.PORT || 3000}`;
+const CLIENT_URI =
+  process.env.REACT_APP_API || `http://localhost:${process.env.PORT || 3000}`;
 
 // Use the routes provided by the Nylas Node SDK to quickly implement
 // the authentication flow


### PR DESCRIPTION
# Description
Update server code for all use cases to use an environment variable for the local client server URL (`CLIENT_URI`), with a fall back default of `localhost:PORT` when the environment variable is not configured

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.