### PR TITLE
[all use cases] update all react code to use an environment variable for the local api server url

### DIFF
--- a/packages/read-and-create-calendar-events/frontend/react/src/CalendarClient.jsx
+++ b/packages/read-and-create-calendar-events/frontend/react/src/CalendarClient.jsx
@@ -5,7 +5,8 @@ import { styles } from './styles';
 
 function CalendarClient({ userId }) {
   const [primaryCalendar, setPrimaryCalendar] = useState(null);
-  const serverBaseUrl = 'http://localhost:9000';
+  const serverBaseUrl =
+    import.meta.env.VITE_SERVER_URI || 'http://localhost:9000';
 
   useEffect(() => {
     const getCalendars = async () => {

--- a/packages/read-and-create-calendar-events/frontend/react/src/index.jsx
+++ b/packages/read-and-create-calendar-events/frontend/react/src/index.jsx
@@ -5,10 +5,11 @@ import App from './App';
 import { NylasProvider } from '@nylas/nylas-react';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
+const SERVER_URI = import.meta.env.VITE_SERVER_URI || 'http://localhost:9000';
 
 root.render(
   <React.StrictMode>
-    <NylasProvider serverBaseUrl="http://localhost:9000">
+    <NylasProvider serverBaseUrl={SERVER_URI}>
       <App />
     </NylasProvider>
   </React.StrictMode>

--- a/packages/read-emails/frontend/react/src/App.jsx
+++ b/packages/read-emails/frontend/react/src/App.jsx
@@ -37,7 +37,10 @@ function App() {
   return !userId ? (
     <NylasLogin />
   ) : (
-    <EmailList serverBaseUrl={'http://localhost:9000'} userId={userId} />
+    <EmailList
+      serverBaseUrl={import.meta.env.VITE_SERVER_URI || 'http://localhost:9000'}
+      userId={userId}
+    />
   );
 }
 

--- a/packages/read-emails/frontend/react/src/App.jsx
+++ b/packages/read-emails/frontend/react/src/App.jsx
@@ -5,6 +5,7 @@ import EmailList from './EmailList';
 function App() {
   const nylas = useNylas();
   const [userId, setUserId] = useState('');
+  const SERVER_URI = import.meta.env.VITE_SERVER_URI || 'http://localhost:9000';
 
   useEffect(() => {
     if (!nylas) {
@@ -37,10 +38,7 @@ function App() {
   return !userId ? (
     <NylasLogin />
   ) : (
-    <EmailList
-      serverBaseUrl={import.meta.env.VITE_SERVER_URI || 'http://localhost:9000'}
-      userId={userId}
-    />
+    <EmailList serverBaseUrl={SERVER_URI} userId={userId} />
   );
 }
 

--- a/packages/read-emails/frontend/react/src/index.jsx
+++ b/packages/read-emails/frontend/react/src/index.jsx
@@ -4,10 +4,11 @@ import App from './App';
 import { NylasProvider } from '@nylas/nylas-react';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
+const SERVER_URI = import.meta.env.VITE_SERVER_URI || 'http://localhost:9000';
 
 root.render(
   <React.StrictMode>
-    <NylasProvider serverBaseUrl="http://localhost:9000">
+    <NylasProvider serverBaseUrl={SERVER_URI}>
       <App />
     </NylasProvider>
   </React.StrictMode>

--- a/packages/send-and-read-emails/frontend/react/src/index.jsx
+++ b/packages/send-and-read-emails/frontend/react/src/index.jsx
@@ -4,10 +4,11 @@ import App from './App';
 import { NylasProvider } from '@nylas/nylas-react';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
+const SERVER_URI = import.meta.env.VITE_SERVER_URI || 'http://localhost:9000';
 
 root.render(
   <React.StrictMode>
-    <NylasProvider serverBaseUrl="http://localhost:9000">
+    <NylasProvider serverBaseUrl={SERVER_URI}>
       <App />
     </NylasProvider>
   </React.StrictMode>

--- a/packages/send-emails/frontend/react/src/index.jsx
+++ b/packages/send-emails/frontend/react/src/index.jsx
@@ -4,10 +4,11 @@ import App from './App';
 import { NylasProvider } from '@nylas/nylas-react';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
+const SERVER_URI = import.meta.env.VITE_SERVER_URI || 'http://localhost:9000';
 
 root.render(
   <React.StrictMode>
-    <NylasProvider serverBaseUrl="http://localhost:9000">
+    <NylasProvider serverBaseUrl={SERVER_URI}>
       <App />
     </NylasProvider>
   </React.StrictMode>


### PR DESCRIPTION
# Description
Update react client code for all use cases to use an environment variable for the local backend server URL (SERVER_URI), with a fall back default of `localhost:PORT` when the environment variable is not configured

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.