### PR TITLE
[read-email] update npm command for vue frontend

### DIFF
--- a/packages/read-emails/frontend/vue/package.json
+++ b/packages/read-emails/frontend/vue/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "vue-cli-service serve --port 3000",
+    "start": "vue-cli-service serve --port 3000",
     "build": "vue-cli-service build"
   },
   "dependencies": {


### PR DESCRIPTION
# Description
`scripts/start.js` fails to serve vue frontend for read-emails use-case.

# What you did
Updated npm run script command for vue from `npm run serve` to `npm run start` to match call from `scripts/start.js` for react frontends.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.