### PR TITLE
[Sample Calendar App] Fix invalid date bug

### DIFF
--- a/packages/read-and-create-calendar-events/frontend/react/src/utils/date.js
+++ b/packages/read-and-create-calendar-events/frontend/react/src/utils/date.js
@@ -23,8 +23,8 @@ export const displayMeetingTime = (timeframe) => {
 };
 
 export const getLocalDateString = (date) => {
-  const localDate = date.toLocaleDateString('en-CA', { hour12: false });
-  const localTime = date.toLocaleTimeString('en-CA', { hour12: false });
+  const localDate = date.toLocaleDateString('en-CA', { hourCycle: 'h23' });
+  const localTime = date.toLocaleTimeString('en-CA', { hourCycle: 'h23' });
   return localDate + 'T' + localTime.split(':').slice(0, 2).join(':');
 };
 


### PR DESCRIPTION
# Description
Fixes issue with Nylas API receiving invalid time between 12:00am and 12:59am.

Turns out `en-CA` locale defaults to a `h24` cycle (01:00 to 24:59) instead of the assumed `h23` cycle (0:00 to 23:59).  Passing the `{ hourCycle: 'h23' }` parameter fixes this issue.

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.