### PR TITLE
[Calendar Sample App] Add Default Start and End Times to Create Event

### DIFF
--- a/packages/read-and-create-calendar-events/backend/node-express/route.js
+++ b/packages/read-and-create-calendar-events/backend/node-express/route.js
@@ -76,7 +76,12 @@ exports.createEvents = async (req, res, nylasClient) => {
   event.description = description;
   event.when.startTime = startTime;
   event.when.endTime = endTime;
-  event.participants = participants;
+
+  if (participants) {
+    event.participants = participants
+      .split(/\s*,\s*/)
+      .map((email) => ({ email }));
+  }
 
   event.save();
 

--- a/packages/read-and-create-calendar-events/frontend/react/src/App.jsx
+++ b/packages/read-and-create-calendar-events/frontend/react/src/App.jsx
@@ -46,13 +46,11 @@ function App() {
         .then((user) => {
           const { id } = JSON.parse(user);
           setUserId(id);
+          sessionStorage.setItem('userId', id);
         })
-        .catch((err) => {
-          console.error('An error occurred parsing the response:', err);
+        .catch((error) => {
+          console.error('An error occurred parsing the response:', error);
         });
-    }
-    if (params.has('userId')) {
-      setUserId(params.get('userId'));
     }
   }, [nylas]);
 

--- a/packages/read-and-create-calendar-events/frontend/react/src/App.jsx
+++ b/packages/read-and-create-calendar-events/frontend/react/src/App.jsx
@@ -154,10 +154,6 @@ function App() {
     getPrimaryCalendarEvents();
   };
 
-  const refresh = () => {
-    getPrimaryCalendarEvents();
-  };
-
   return (
     <Layout
       showMenu={!!userId}

--- a/packages/read-and-create-calendar-events/frontend/react/src/CreateEventForm.jsx
+++ b/packages/read-and-create-calendar-events/frontend/react/src/CreateEventForm.jsx
@@ -26,8 +26,6 @@ function CreateEventForm({
 
   const now = new Date();
 
-  console.log(endTime);
-
   const createEvent = async (e) => {
     e.preventDefault();
 

--- a/packages/read-and-create-calendar-events/frontend/react/src/CreateEventForm.jsx
+++ b/packages/read-and-create-calendar-events/frontend/react/src/CreateEventForm.jsx
@@ -5,7 +5,7 @@ import {
   getLocalDateString,
   getDefaultEventStartTime,
   getDefaultEventEndTime,
-  getMinimumEndTime,
+  getMinimumEventEndTime,
 } from './utils/date';
 
 function CreateEventForm({
@@ -124,7 +124,7 @@ function CreateEventForm({
                 setEndTime(event.target.value);
               }}
               value={endTime}
-              min={getLocalDateString(getMinimumEndTime(startTime))}
+              min={getLocalDateString(getMinimumEventEndTime(startTime))}
             />
           </div>
         </div>

--- a/packages/read-and-create-calendar-events/frontend/react/src/CreateEventForm.jsx
+++ b/packages/read-and-create-calendar-events/frontend/react/src/CreateEventForm.jsx
@@ -5,6 +5,7 @@ import {
   getLocalDateString,
   getDefaultEventStartTime,
   getDefaultEventEndTime,
+  currentTimeAddMinutes,
 } from './utils/date';
 
 function CreateEventForm({
@@ -43,9 +44,7 @@ function CreateEventForm({
           title,
           description,
           calendarId,
-          participants: participants
-            .split(/\s*,\s*/)
-            .map((email) => ({ email })),
+          participants,
         }),
       });
 
@@ -124,41 +123,10 @@ function CreateEventForm({
               name="event-end-time"
               className={endTime === '' ? 'placeholder' : ''}
               onChange={(event) => {
-                console.log(event.target.value);
                 setEndTime(event.target.value);
               }}
-              // readOnly={true}
-              // step={60 * 60}
-              // defaultValue={new Date().setTime(
-              //   now.getTime() + 3 * 60 * 60 * 1000
-              // )}
-              // on
-              // onKeyUp={(e) => console.log(e)}
-              // onClick={(e) => {
-              //   console.log(e);
-              //   // if (e.value)
-              //   // if (endTime === '') {
-              //   //   // console.log(endTime);
-              //   //   let newDate = new Date().setTime(
-              //   //     now.getTime() + 3 * 60 * 60 * 1000
-              //   //   );
-              //   //   // console.log(getLocalDateString(newDate));
-              //   //   endTime = getLocalDateString(newDate);
-              //   // setEndTime('');
-              //   // setEndTime(
-              //   //   new Date().setTime(now.getTime() + 3 * 60 * 60 * 1000)
-              //   // );
-              //   // console.log(endTime);
-              //   // setImmediate(() => setEndTime(''));
-              //   // setTimeout(() => {
-              //   //   setEndTime('');
-              //   // }, 0);
-              //   // }
-              // }}
-              // data-date={now}
-              // onClick={(e) => console.log(e)}
               value={endTime}
-              min={getLocalDateString(now)}
+              min={getLocalDateString(currentTimeAddMinutes(1))}
             />
           </div>
         </div>

--- a/packages/read-and-create-calendar-events/frontend/react/src/CreateEventForm.jsx
+++ b/packages/read-and-create-calendar-events/frontend/react/src/CreateEventForm.jsx
@@ -1,6 +1,11 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { applyTimezone, getLocalDateString } from './utils/date';
+import {
+  applyTimezone,
+  getLocalDateString,
+  getDefaultEventStartTime,
+  getDefaultEventEndTime,
+} from './utils/date';
 
 function CreateEventForm({
   userId,
@@ -10,11 +15,11 @@ function CreateEventForm({
   setToastNotification,
   refresh,
 }) {
-  const [startTime, setStartTime] = useState('');
-  const [endTime, setEndTime] = useState('');
+  const [startTime, setStartTime] = useState(getDefaultEventStartTime());
+  const [endTime, setEndTime] = useState(getDefaultEventEndTime());
   const [title, setTitle] = useState('');
   const [participants, setParticipants] = useState(
-    sessionStorage.getItem('userEmail')
+    sessionStorage.getItem('userEmail') || ''
   );
   const [description, setDescription] = useState('');
 
@@ -119,8 +124,39 @@ function CreateEventForm({
               name="event-end-time"
               className={endTime === '' ? 'placeholder' : ''}
               onChange={(event) => {
+                console.log(event.target.value);
                 setEndTime(event.target.value);
               }}
+              // readOnly={true}
+              // step={60 * 60}
+              // defaultValue={new Date().setTime(
+              //   now.getTime() + 3 * 60 * 60 * 1000
+              // )}
+              // on
+              // onKeyUp={(e) => console.log(e)}
+              // onClick={(e) => {
+              //   console.log(e);
+              //   // if (e.value)
+              //   // if (endTime === '') {
+              //   //   // console.log(endTime);
+              //   //   let newDate = new Date().setTime(
+              //   //     now.getTime() + 3 * 60 * 60 * 1000
+              //   //   );
+              //   //   // console.log(getLocalDateString(newDate));
+              //   //   endTime = getLocalDateString(newDate);
+              //   // setEndTime('');
+              //   // setEndTime(
+              //   //   new Date().setTime(now.getTime() + 3 * 60 * 60 * 1000)
+              //   // );
+              //   // console.log(endTime);
+              //   // setImmediate(() => setEndTime(''));
+              //   // setTimeout(() => {
+              //   //   setEndTime('');
+              //   // }, 0);
+              //   // }
+              // }}
+              // data-date={now}
+              // onClick={(e) => console.log(e)}
               value={endTime}
               min={getLocalDateString(now)}
             />

--- a/packages/read-and-create-calendar-events/frontend/react/src/CreateEventForm.jsx
+++ b/packages/read-and-create-calendar-events/frontend/react/src/CreateEventForm.jsx
@@ -26,6 +26,8 @@ function CreateEventForm({
 
   const now = new Date();
 
+  console.log(endTime);
+
   const createEvent = async (e) => {
     e.preventDefault();
 
@@ -108,7 +110,6 @@ function CreateEventForm({
             <input
               type="datetime-local"
               name="event-start-time"
-              className={startTime === '' ? 'placeholder' : ''}
               onChange={(event) => {
                 setStartTime(event.target.value);
               }}
@@ -121,7 +122,6 @@ function CreateEventForm({
             <input
               type="datetime-local"
               name="event-end-time"
-              className={endTime === '' ? 'placeholder' : ''}
               onChange={(event) => {
                 setEndTime(event.target.value);
               }}

--- a/packages/read-and-create-calendar-events/frontend/react/src/CreateEventForm.jsx
+++ b/packages/read-and-create-calendar-events/frontend/react/src/CreateEventForm.jsx
@@ -5,7 +5,7 @@ import {
   getLocalDateString,
   getDefaultEventStartTime,
   getDefaultEventEndTime,
-  currentTimeAddMinutes,
+  getMinimumEndTime,
 } from './utils/date';
 
 function CreateEventForm({
@@ -126,7 +126,7 @@ function CreateEventForm({
                 setEndTime(event.target.value);
               }}
               value={endTime}
-              min={getLocalDateString(currentTimeAddMinutes(1))}
+              min={getLocalDateString(getMinimumEndTime(startTime))}
             />
           </div>
         </div>

--- a/packages/read-and-create-calendar-events/frontend/react/src/NylasLogin.jsx
+++ b/packages/read-and-create-calendar-events/frontend/react/src/NylasLogin.jsx
@@ -10,8 +10,9 @@ const NylasLogin = ({ email, setEmail }) => {
   const loginUser = (e) => {
     e.preventDefault();
     setIsLoading(true);
+    console.log('setting email');
     sessionStorage.setItem('userEmail', email);
-
+    console.log('email should be set');
     nylas.authWithRedirect({
       emailAddress: email,
       successRedirectUrl: '',

--- a/packages/read-and-create-calendar-events/frontend/react/src/NylasLogin.jsx
+++ b/packages/read-and-create-calendar-events/frontend/react/src/NylasLogin.jsx
@@ -10,9 +10,9 @@ const NylasLogin = ({ email, setEmail }) => {
   const loginUser = (e) => {
     e.preventDefault();
     setIsLoading(true);
-    console.log('setting email');
+
     sessionStorage.setItem('userEmail', email);
-    console.log('email should be set');
+
     nylas.authWithRedirect({
       emailAddress: email,
       successRedirectUrl: '',

--- a/packages/read-and-create-calendar-events/frontend/react/src/styles/calendar.scss
+++ b/packages/read-and-create-calendar-events/frontend/react/src/styles/calendar.scss
@@ -476,14 +476,6 @@ a {
           font-size: $fs-16;
           font-weight: 400;
           line-height: 1.5;
-
-          &::placeholder {
-            color: $color-grey-700;
-          }
-
-          &.placeholder {
-            color: $color-grey-700;
-          }
         }
 
         textarea {

--- a/packages/read-and-create-calendar-events/frontend/react/src/utils/date.js
+++ b/packages/read-and-create-calendar-events/frontend/react/src/utils/date.js
@@ -54,12 +54,6 @@ export const currentTime = () => {
   return getLocalDateString(date);
 };
 
-export const currentTimeAddMinutes = (minutes) => {
-  const date = new Date();
-  date.setMinutes(date.getMinutes() + minutes);
-  return date;
-};
-
 export const getEventDate = (calendarEvent) => {
   return new Date(
     calendarEvent.when.object === 'date'
@@ -90,20 +84,34 @@ export const getDefaultEventEndTime = () => {
   return getLocalDateString(endDate);
 };
 
-const getNextHalfHour = () => {
-  const date = new Date();
-  const currentMinutes = date.getMinutes();
-  const minutesToAdd = 30 - (currentMinutes % 30 || 0);
-
-  return currentTimeAddMinutes(minutesToAdd);
-  // date.setMinutes(currentMinutes + minutesToAdd);
-
-  // return date;
-};
-
 export const getOneHourFromPassedTimestamp = (timestamp) => {
   const date = new Date(timestamp);
   date.setHours(timestamp.getHours() + 1);
 
   return date;
+};
+
+// export const currentTimeAddMinutes = (minutes) => {
+//   const date = new Date();
+//   date.setMinutes(date.getMinutes() + minutes);
+//   return date;
+// };
+
+export const getMinimumEndTime = (dateString) => {
+  const date = new Date(dateString);
+  date.setMinutes(date.getMinutes() + 1);
+  return date;
+};
+
+const getNextHalfHour = () => {
+  const date = new Date();
+  const currentMinutes = date.getMinutes();
+  const minutesToAdd = 30 - (currentMinutes % 30 || 0);
+
+  date.setMinutes(date.getMinutes() + minutesToAdd);
+  return date;
+  // return currentTimeAddMinutes(minutesToAdd);
+  // date.setMinutes(currentMinutes + minutesToAdd);
+
+  // return date;
 };

--- a/packages/read-and-create-calendar-events/frontend/react/src/utils/date.js
+++ b/packages/read-and-create-calendar-events/frontend/react/src/utils/date.js
@@ -54,10 +54,10 @@ export const currentTime = () => {
   return getLocalDateString(date);
 };
 
-export const currentTimePlusHalfHour = () => {
+export const currentTimeAddMinutes = (minutes) => {
   const date = new Date();
-  date.setMinutes(date.getMinutes() + 30);
-  return getLocalDateString(date);
+  date.setMinutes(date.getMinutes() + minutes);
+  return date;
 };
 
 export const getEventDate = (calendarEvent) => {
@@ -95,9 +95,10 @@ const getNextHalfHour = () => {
   const currentMinutes = date.getMinutes();
   const minutesToAdd = 30 - (currentMinutes % 30 || 0);
 
-  date.setMinutes(currentMinutes + minutesToAdd);
+  return currentTimeAddMinutes(minutesToAdd);
+  // date.setMinutes(currentMinutes + minutesToAdd);
 
-  return date;
+  // return date;
 };
 
 export const getOneHourFromPassedTimestamp = (timestamp) => {

--- a/packages/read-and-create-calendar-events/frontend/react/src/utils/date.js
+++ b/packages/read-and-create-calendar-events/frontend/react/src/utils/date.js
@@ -95,7 +95,7 @@ export const getDefaultEventEndTime = () => {
   return getLocalDateString(endDate);
 };
 
-export const getMinimumEndTime = (dateString) => {
+export const getMinimumEventEndTime = (dateString) => {
   const date = new Date(dateString);
   date.setMinutes(date.getMinutes() + 1);
   return date;

--- a/packages/read-and-create-calendar-events/frontend/react/src/utils/date.js
+++ b/packages/read-and-create-calendar-events/frontend/react/src/utils/date.js
@@ -1,11 +1,31 @@
 import { DateTime } from 'luxon';
 
-export const get12HourTime = (timestamp) => {
+const get12HourTime = (timestamp) => {
   return new Date(timestamp * 1000).toLocaleTimeString('en-US', {
     hour: 'numeric',
     minute: 'numeric',
     hour12: true,
   });
+};
+
+const getNextHalfHour = () => {
+  const date = new Date();
+  const currentMinutes = date.getMinutes();
+  const minutesToAdd = 30 - (currentMinutes % 30 || 0);
+
+  date.setMinutes(date.getMinutes() + minutesToAdd);
+  return date;
+};
+
+const getOneHourFromPassedTimestamp = (timestamp) => {
+  const date = new Date(timestamp);
+  date.setHours(timestamp.getHours() + 1);
+
+  return date;
+};
+
+const getUnixTimestamp = (date) => {
+  return Math.floor(date.getTime() / 1000);
 };
 
 export const displayMeetingTime = (timeframe) => {
@@ -34,10 +54,6 @@ export const applyTimezone = (date) => {
   return getUnixTimestamp(localizedDate);
 };
 
-export const getUnixTimestamp = (date) => {
-  return Math.floor(date.getTime() / 1000);
-};
-
 export const getTodaysDateTimestamp = () => {
   const date = new Date();
   return applyTimezone(getLocalDateString(date));
@@ -47,11 +63,6 @@ export const getSevenDaysFromTodayDateTimestamp = () => {
   const date = new Date();
   date.setDate(date.getDate() + 7);
   return applyTimezone(getLocalDateString(new Date(date)));
-};
-
-export const currentTime = () => {
-  const date = new Date();
-  return getLocalDateString(date);
 };
 
 export const getEventDate = (calendarEvent) => {
@@ -84,34 +95,8 @@ export const getDefaultEventEndTime = () => {
   return getLocalDateString(endDate);
 };
 
-export const getOneHourFromPassedTimestamp = (timestamp) => {
-  const date = new Date(timestamp);
-  date.setHours(timestamp.getHours() + 1);
-
-  return date;
-};
-
-// export const currentTimeAddMinutes = (minutes) => {
-//   const date = new Date();
-//   date.setMinutes(date.getMinutes() + minutes);
-//   return date;
-// };
-
 export const getMinimumEndTime = (dateString) => {
   const date = new Date(dateString);
   date.setMinutes(date.getMinutes() + 1);
   return date;
-};
-
-const getNextHalfHour = () => {
-  const date = new Date();
-  const currentMinutes = date.getMinutes();
-  const minutesToAdd = 30 - (currentMinutes % 30 || 0);
-
-  date.setMinutes(date.getMinutes() + minutesToAdd);
-  return date;
-  // return currentTimeAddMinutes(minutesToAdd);
-  // date.setMinutes(currentMinutes + minutesToAdd);
-
-  // return date;
 };

--- a/packages/read-and-create-calendar-events/frontend/react/src/utils/date.js
+++ b/packages/read-and-create-calendar-events/frontend/react/src/utils/date.js
@@ -78,3 +78,31 @@ export const getFormattedDate = (event) => {
 export const getTimezoneCode = () => {
   return DateTime.local().toFormat('ZZZZ');
 };
+
+export const getDefaultEventStartTime = () => {
+  const startDate = getNextHalfHour();
+  return getLocalDateString(startDate);
+};
+
+export const getDefaultEventEndTime = () => {
+  const startDate = getNextHalfHour();
+  const endDate = getOneHourFromPassedTimestamp(startDate);
+  return getLocalDateString(endDate);
+};
+
+const getNextHalfHour = () => {
+  const date = new Date();
+  const currentMinutes = date.getMinutes();
+  const minutesToAdd = 30 - (currentMinutes % 30 || 0);
+
+  date.setMinutes(currentMinutes + minutesToAdd);
+
+  return date;
+};
+
+export const getOneHourFromPassedTimestamp = (timestamp) => {
+  const date = new Date(timestamp);
+  date.setHours(timestamp.getHours() + 1);
+
+  return date;
+};


### PR DESCRIPTION
# Description
Provides default start and end times in the `Create Event` form.

# Change Summary
- `startTime` defaults to next half hour interval (i.e.`:00 or :30`)
- `endTime` defaults to one hour after default start time
- Set minimum `endTime` to `startTime + 1 minute`. (API calls where `startTime === endTime` fail)
- Removed unused date functions.
- Adds `userId` to `sessionStorage` to match Email Sample App
- moved preparing `participants` array to the backend

# Screenshot
<img width="755" alt="Screenshot 2022-11-17 at 4 58 51 PM" src="https://user-images.githubusercontent.com/43771331/202585356-9a9d6745-fba7-4f72-bd45-61d795f3d0ac.png">