### PR TITLE
Using strings to convert date time was not working as expected

### DIFF
--- a/packages/read-and-create-calendar-events/frontend/react/src/CreateEventForm.jsx
+++ b/packages/read-and-create-calendar-events/frontend/react/src/CreateEventForm.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   applyTimezone,
-  getLocalDateString,
+  convertUTCDate,
   getDefaultEventStartTime,
   getDefaultEventEndTime,
   getMinimumEventEndTime,
@@ -58,8 +58,8 @@ function CreateEventForm({
       console.log('Event created:', data);
 
       // reset form fields
-      setStartTime(getLocalDateString(new Date()));
-      setEndTime(getLocalDateString(new Date()));
+      setStartTime(convertUTCDate(new Date()));
+      setEndTime(convertUTCDate(new Date()));
       setTitle('');
       setDescription('');
       setShowCreateEventForm(false);
@@ -112,7 +112,7 @@ function CreateEventForm({
                 setStartTime(event.target.value);
               }}
               value={startTime}
-              min={getLocalDateString(now)}
+              min={convertUTCDate(now)}
             />
           </div>
           <div className="field-container">
@@ -124,7 +124,7 @@ function CreateEventForm({
                 setEndTime(event.target.value);
               }}
               value={endTime}
-              min={getLocalDateString(getMinimumEventEndTime(startTime))}
+              min={convertUTCDate(getMinimumEventEndTime(startTime))}
             />
           </div>
         </div>

--- a/packages/read-and-create-calendar-events/frontend/react/src/utils/date.js
+++ b/packages/read-and-create-calendar-events/frontend/react/src/utils/date.js
@@ -42,10 +42,17 @@ export const displayMeetingTime = (timeframe) => {
   } - ${endTime}`;
 };
 
-export const getLocalDateString = (date) => {
-  const localDate = date.toLocaleDateString('en-CA', { hourCycle: 'h23' });
-  const localTime = date.toLocaleTimeString('en-CA', { hourCycle: 'h23' });
-  return localDate + 'T' + localTime.split(':').slice(0, 2).join(':');
+export const convertUTCDate = (date) => {
+  const utcDate = new Date(
+    date.getTime() + date.getTimezoneOffset() * 60 * 1000
+  );
+
+  const offset = date.getTimezoneOffset() / 60;
+  const hours = date.getHours();
+
+  utcDate.setHours(hours - offset);
+
+  return utcDate;
 };
 
 export const applyTimezone = (date) => {
@@ -56,13 +63,13 @@ export const applyTimezone = (date) => {
 
 export const getTodaysDateTimestamp = () => {
   const date = new Date();
-  return applyTimezone(getLocalDateString(date));
+  return applyTimezone(convertUTCDate(date));
 };
 
 export const getSevenDaysFromTodayDateTimestamp = () => {
   const date = new Date();
   date.setDate(date.getDate() + 7);
-  return applyTimezone(getLocalDateString(new Date(date)));
+  return applyTimezone(convertUTCDate(new Date(date)));
 };
 
 export const getEventDate = (calendarEvent) => {
@@ -86,17 +93,17 @@ export const getTimezoneCode = () => {
 
 export const getDefaultEventStartTime = () => {
   const startDate = getNextHalfHour();
-  return getLocalDateString(startDate);
+  return convertUTCDate(startDate);
 };
 
 export const getDefaultEventEndTime = () => {
   const startDate = getNextHalfHour();
   const endDate = getOneHourFromPassedTimestamp(startDate);
-  return getLocalDateString(endDate);
+  return convertUTCDate(endDate);
 };
 
-export const getMinimumEventEndTime = (dateString) => {
-  const date = new Date(dateString);
+export const getMinimumEventEndTime = (inputDate) => {
+  const date = new Date(inputDate);
   date.setMinutes(date.getMinutes() + 1);
   return date;
 };


### PR DESCRIPTION
# Description
Looks like we relied upon re-building an ISO string to do a UTC -> local time conversion. This conversion didn't always work.

# Usage
- [x] Updated the date util method to convert UTC to local time

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.