### PR TITLE
Update to Java SDK v1.21.0 and use new toJSON method

### DIFF
--- a/packages/read-and-create-calendar-events/backend/java/build.gradle
+++ b/packages/read-and-create-calendar-events/backend/java/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    implementation('com.nylas.sdk:nylas-java-sdk:1.20.1')
+    implementation('com.nylas.sdk:nylas-java-sdk:1.21.0')
     implementation('com.sparkjava:spark-core:2.9.4')
     implementation('io.github.cdimascio:dotenv-java:2.3.2')
     implementation('com.google.code.gson:gson:2.10.1')

--- a/packages/read-and-create-calendar-events/backend/java/src/main/java/Server.java
+++ b/packages/read-and-create-calendar-events/backend/java/src/main/java/Server.java
@@ -45,10 +45,27 @@ public class Server {
 		application.addRedirectUri(clientUri);
 		System.out.println("Application whitelisted.");
 
+		/*
+		 * Class that handles webhook notifications
+		 */
+		class HandleNotifications implements Tunnel.WebhookHandler {
+			// Handle when an event is created
+			@Override
+			public void onMessage(Delta delta) {
+				if(delta.getTrigger().equals(Webhook.Trigger.EventCreated.getName())) {
+					System.out.println("Webhook trigger received, event created. Details: " + delta);
+				}
+			}
+		}
+
 		// Start the Nylas webhook
 		Tunnel webhookTunnel = new Tunnel.Builder(application, new HandleNotifications()).build();
 		webhookTunnel.connect();
 
+		/*
+		 * '/nylas/generate-auth-url': This route builds the URL for
+		 * authenticating users to your Nylas application via Hosted Authentication
+		 */
 		post("/nylas/generate-auth-url", (request, response) -> {
 			Map<String, String> requestBody = GSON.fromJson(request.body(), JSON_MAP);
 
@@ -234,18 +251,5 @@ public class Server {
 			response.header("Access-Control-Allow-Headers", "X-Requested-With, X-HTTP-Method-Override, Content-Type, Cache-Control, Accept, Authorization");
 			response.type("application/json");
 		});
-	}
-
-	/**
-	 * Class that handles webhook notifications
-	 */
-	static class HandleNotifications implements Tunnel.WebhookHandler {
-		@Override
-		public void onMessage(Delta delta) {
-			// Handle when an event is created
-			if(delta.getTrigger().equals(Webhook.Trigger.EventCreated.getName())) {
-				System.out.println("Webhook trigger received, event created. Details: " + delta);
-			}
-		}
 	}
 }

--- a/packages/read-and-create-calendar-events/backend/java/src/main/java/Server.java
+++ b/packages/read-and-create-calendar-events/backend/java/src/main/java/Server.java
@@ -136,7 +136,7 @@ public class Server {
 			ArrayList<String> eventList = new ArrayList<>();
 
 			// Return the events
-			events.forEach(event -> eventList.add(GSON.toJson(event)));
+			events.forEach(event -> eventList.add(event.toJSON()));
 			return eventList;
 		});
 
@@ -151,7 +151,7 @@ public class Server {
 			ArrayList<String> calendarList = new ArrayList<>();
 
 			// Return the calendars
-			calendars.forEach(thread -> calendarList.add(GSON.toJson(thread)));
+			calendars.forEach(thread -> calendarList.add(thread.toJSON()));
 			return calendarList;
 		});
 
@@ -190,7 +190,7 @@ public class Server {
 			}
 
 			// Save the event
-			return GSON.toJson(nylas.events().save(event, true));
+			return nylas.events().save(event, true).toJSON();
 		});
 	}
 

--- a/packages/read-emails/backend/java/build.gradle
+++ b/packages/read-emails/backend/java/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    implementation('com.nylas.sdk:nylas-java-sdk:1.20.1')
+    implementation('com.nylas.sdk:nylas-java-sdk:1.21.0')
     implementation('com.sparkjava:spark-core:2.9.4')
     implementation('io.github.cdimascio:dotenv-java:2.3.2')
     implementation('com.google.code.gson:gson:2.10.1')

--- a/packages/read-emails/backend/java/src/main/java/Server.java
+++ b/packages/read-emails/backend/java/src/main/java/Server.java
@@ -125,7 +125,7 @@ public class Server {
 			RemoteCollection<Thread> threads = nylas.threads().expanded(new ThreadQuery().limit(5));
 			ArrayList<String> threadList = new ArrayList<>();
 
-			threads.forEach(thread -> threadList.add(GSON.toJson(thread)));
+			threads.forEach(thread -> threadList.add(thread.toJSON()));
 			return threadList;
 		});
 
@@ -137,7 +137,7 @@ public class Server {
 
 			String messageId = request.queryParams("id");
 
-			return GSON.toJson(nylas.messages().get(messageId));
+			return nylas.messages().get(messageId).toJSON();
 		});
 
 		get("/nylas/file", (request, response) -> {

--- a/packages/read-emails/backend/java/src/main/java/Server.java
+++ b/packages/read-emails/backend/java/src/main/java/Server.java
@@ -44,10 +44,29 @@ public class Server {
 		application.addRedirectUri(clientUri);
 		System.out.println("Application whitelisted.");
 
+		/*
+		 * Class that handles webhook notifications
+		 */
+		class HandleNotifications implements Tunnel.WebhookHandler {
+			// Handle when a new message is created (sent)
+			@Override
+			public void onMessage(Delta delta) {
+				if(delta.getTrigger().equals(Webhook.Trigger.MessageCreated.getName())) {
+					System.out.println("Webhook trigger received, message created. Details: " + delta);
+				} else if(delta.getTrigger().equals(Webhook.Trigger.AccountConnected.getName())) {
+					System.out.println("Webhook trigger received, account connected. Details: " + delta);
+				}
+			}
+		}
+
 		// Start the Nylas webhook
 		Tunnel webhookTunnel = new Tunnel.Builder(application, new HandleNotifications()).build();
 		webhookTunnel.connect();
 
+		/*
+		 * '/nylas/generate-auth-url': This route builds the URL for
+		 * authenticating users to your Nylas application via Hosted Authentication
+		 */
 		post("/nylas/generate-auth-url", (request, response) -> {
 			Map<String, String> requestBody = GSON.fromJson(request.body(), JSON_MAP);
 
@@ -198,20 +217,5 @@ public class Server {
 			response.header("Access-Control-Allow-Headers", "X-Requested-With, X-HTTP-Method-Override, Content-Type, Cache-Control, Accept, Authorization");
 			response.type("application/json");
 		});
-	}
-
-	/**
-	 * Class that handles webhook notifications
-	 */
-	static class HandleNotifications implements Tunnel.WebhookHandler {
-		@Override
-		public void onMessage(Delta delta) {
-			// Handle when a new message is created (sent)
-			if(delta.getTrigger().equals(Webhook.Trigger.MessageCreated.getName())) {
-				System.out.println("Webhook trigger received, message created. Details: " + delta);
-			} else if(delta.getTrigger().equals(Webhook.Trigger.AccountConnected.getName())) {
-				System.out.println("Webhook trigger received, account connected. Details: " + delta);
-			}
-		}
 	}
 }

--- a/packages/send-and-read-emails/backend/java/build.gradle
+++ b/packages/send-and-read-emails/backend/java/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    implementation('com.nylas.sdk:nylas-java-sdk:1.20.1')
+    implementation('com.nylas.sdk:nylas-java-sdk:1.21.0')
     implementation('com.sparkjava:spark-core:2.9.4')
     implementation('io.github.cdimascio:dotenv-java:2.3.2')
     implementation('com.google.code.gson:gson:2.10.1')

--- a/packages/send-and-read-emails/backend/java/src/main/java/Server.java
+++ b/packages/send-and-read-emails/backend/java/src/main/java/Server.java
@@ -45,10 +45,29 @@ public class Server {
 		application.addRedirectUri(clientUri);
 		System.out.println("Application whitelisted.");
 
+		/*
+		 * Class that handles webhook notifications
+		 */
+		class HandleNotifications implements Tunnel.WebhookHandler {
+			// Handle when a new message is created (sent)
+			@Override
+			public void onMessage(Delta delta) {
+				if(delta.getTrigger().equals(Webhook.Trigger.MessageCreated.getName())) {
+					System.out.println("Webhook trigger received, message created. Details: " + delta);
+				} else if(delta.getTrigger().equals(Webhook.Trigger.AccountConnected.getName())) {
+					System.out.println("Webhook trigger received, account connected. Details: " + delta);
+				}
+			}
+		}
+
 		// Start the Nylas webhook
 		Tunnel webhookTunnel = new Tunnel.Builder(application, new HandleNotifications()).build();
 		webhookTunnel.connect();
 
+		/*
+		 * '/nylas/generate-auth-url': This route builds the URL for
+		 * authenticating users to your Nylas application via Hosted Authentication
+		 */
 		post("/nylas/generate-auth-url", (request, response) -> {
 			Map<String, String> requestBody = GSON.fromJson(request.body(), JSON_MAP);
 
@@ -218,20 +237,5 @@ public class Server {
 			response.header("Access-Control-Allow-Headers", "X-Requested-With, X-HTTP-Method-Override, Content-Type, Cache-Control, Accept, Authorization");
 			response.type("application/json");
 		});
-	}
-
-	/**
-	 * Class that handles webhook notifications
-	 */
-	static class HandleNotifications implements Tunnel.WebhookHandler {
-		@Override
-		public void onMessage(Delta delta) {
-			// Handle when a new message is created (sent)
-			if(delta.getTrigger().equals(Webhook.Trigger.MessageCreated.getName())) {
-				System.out.println("Webhook trigger received, message created. Details: " + delta);
-			} else if(delta.getTrigger().equals(Webhook.Trigger.AccountConnected.getName())) {
-				System.out.println("Webhook trigger received, account connected. Details: " + delta);
-			}
-		}
 	}
 }

--- a/packages/send-and-read-emails/backend/java/src/main/java/Server.java
+++ b/packages/send-and-read-emails/backend/java/src/main/java/Server.java
@@ -128,11 +128,8 @@ public class Server {
 			draft.setSubject(requestBody.get("subject"));
 			draft.setBody(requestBody.get("body"));
 
-			// Send the draft
-			Message message = nylas.drafts().send(draft);
-
-			// Return the sent message object
-			return GSON.toJson(message);
+			// Send the draft and return the message
+			return nylas.drafts().send(draft).toJSON();
 		});
 
 		get("/nylas/read-emails", (request, response) -> {
@@ -160,7 +157,7 @@ public class Server {
 
 			String messageId = request.queryParams("id");
 
-			return GSON.toJson(nylas.messages().get(messageId));
+			return nylas.messages().get(messageId).toJSON();
 		});
 
 		get("/nylas/file", (request, response) -> {

--- a/packages/send-emails/backend/java/build.gradle
+++ b/packages/send-emails/backend/java/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    implementation('com.nylas.sdk:nylas-java-sdk:1.20.1')
+    implementation('com.nylas.sdk:nylas-java-sdk:1.21.0')
     implementation('com.sparkjava:spark-core:2.9.4')
     implementation('io.github.cdimascio:dotenv-java:2.3.2')
     implementation('com.google.code.gson:gson:2.10.1')

--- a/packages/send-emails/backend/java/src/main/java/Server.java
+++ b/packages/send-emails/backend/java/src/main/java/Server.java
@@ -1,7 +1,6 @@
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.nylas.*;
-import com.nylas.Thread;
 import com.nylas.services.Tunnel;
 import com.nylas.Notification.Delta;
 import io.github.cdimascio.dotenv.Dotenv;
@@ -13,7 +12,6 @@ import utils.MockDB;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -132,7 +130,7 @@ public class Server {
 			Message message = nylas.drafts().send(draft);
 
 			// Return the sent message object
-			return GSON.toJson(message);
+			return message.toJSON();
 		});
 	}
 

--- a/packages/send-emails/backend/java/src/main/java/Server.java
+++ b/packages/send-emails/backend/java/src/main/java/Server.java
@@ -43,10 +43,29 @@ public class Server {
 		application.addRedirectUri(clientUri);
 		System.out.println("Application whitelisted.");
 
+		/*
+		 * Class that handles webhook notifications
+		 */
+		class HandleNotifications implements Tunnel.WebhookHandler {
+			// Handle when a new message is created (sent)
+			@Override
+			public void onMessage(Delta delta) {
+				if(delta.getTrigger().equals(Webhook.Trigger.MessageCreated.getName())) {
+					System.out.println("Webhook trigger received, message created. Details: " + delta);
+				} else if(delta.getTrigger().equals(Webhook.Trigger.AccountConnected.getName())) {
+					System.out.println("Webhook trigger received, account connected. Details: " + delta);
+				}
+			}
+		}
+
 		// Start the Nylas webhook
 		Tunnel webhookTunnel = new Tunnel.Builder(application, new HandleNotifications()).build();
 		webhookTunnel.connect();
 
+		/*
+		 * '/nylas/generate-auth-url': This route builds the URL for
+		 * authenticating users to your Nylas application via Hosted Authentication
+		 */
 		post("/nylas/generate-auth-url", (request, response) -> {
 			Map<String, String> requestBody = GSON.fromJson(request.body(), JSON_MAP);
 
@@ -174,20 +193,5 @@ public class Server {
 			response.header("Access-Control-Allow-Headers", "X-Requested-With, X-HTTP-Method-Override, Content-Type, Cache-Control, Accept, Authorization");
 			response.type("application/json");
 		});
-	}
-
-	/**
-	 * Class that handles webhook notifications
-	 */
-	static class HandleNotifications implements Tunnel.WebhookHandler {
-		@Override
-		public void onMessage(Delta delta) {
-			// Handle when a new message is created (sent)
-			if(delta.getTrigger().equals(Webhook.Trigger.MessageCreated.getName())) {
-				System.out.println("Webhook trigger received, message created. Details: " + delta);
-			} else if(delta.getTrigger().equals(Webhook.Trigger.AccountConnected.getName())) {
-				System.out.println("Webhook trigger received, account connected. Details: " + delta);
-			}
-		}
 	}
 }


### PR DESCRIPTION
# Description
Upgrade all the Java apps to use the v1.21.0 Java SDK and use the new toJSON() method instead of using GSON to serialize the models.

# Usage
<!-- If your PR brings a new feature or a change to how you use the app, show it off here! -->
```js
// Adding a code snippet also helps if it makes sense to do so :)
```

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.