### PR TITLE
[All Guides] Toast Fixes (Flicker and Min-Width

### DIFF
--- a/packages/read-and-create-calendar-events/frontend/react/src/components/Toast.jsx
+++ b/packages/read-and-create-calendar-events/frontend/react/src/components/Toast.jsx
@@ -7,11 +7,12 @@ import { useEffect } from 'react';
 
 function Toast({ toastNotification, setToastNotification }) {
   useEffect(() => {
-    setTimeout(() => {
+    const timer = setTimeout(() => {
       if (toastNotification) {
         setToastNotification('');
       }
-    }, 3000);
+    }, 5500);
+    return () => clearTimeout(timer);
   }, [toastNotification]);
 
   const icons = { success: SuccessIcon, error: ErrorIcon, close: CloseIcon };

--- a/packages/read-and-create-calendar-events/frontend/react/src/components/Toast.jsx
+++ b/packages/read-and-create-calendar-events/frontend/react/src/components/Toast.jsx
@@ -26,12 +26,14 @@ function Toast({ toastNotification, setToastNotification }) {
       <div className={`toast ${toastNotification}`}>
         <img src={icons[toastNotification]} alt={toastNotification} />
         {message[toastNotification]}
-        <img
-          src={icons.close}
-          alt="Close"
-          className="close"
-          onClick={() => setToastNotification('')}
-        />
+        <div className="dismiss-container">
+          <img
+            src={icons.close}
+            alt="Close"
+            className="close"
+            onClick={() => setToastNotification('')}
+          />
+        </div>
       </div>
     )
   );

--- a/packages/read-and-create-calendar-events/frontend/react/src/styles/style.scss
+++ b/packages/read-and-create-calendar-events/frontend/react/src/styles/style.scss
@@ -69,7 +69,7 @@ button {
   display: flex;
   align-items: center;
   gap: calc(#{$spacing-16} + #{$spacing-4}/ 2);
-  animation: fadeIn 0.5s, fadeOut 2.8s;
+  animation: fadeIn 0.5s, fadeOut 5.6s cubic-bezier(0.76, 0, 0.24, 1);
 
   &.success {
     background-color: $color-green-50;

--- a/packages/read-and-create-calendar-events/frontend/react/src/styles/style.scss
+++ b/packages/read-and-create-calendar-events/frontend/react/src/styles/style.scss
@@ -71,6 +71,7 @@ button {
   gap: calc(#{$spacing-16} + #{$spacing-4}/ 2);
   animation: fadeIn 0.5s, fadeOut 5.6s cubic-bezier(0.76, 0, 0.24, 1);
   min-width: calc(#{$spacing-24} * 14);
+  z-index: 1;
 
   &.success {
     background-color: $color-green-50;

--- a/packages/read-and-create-calendar-events/frontend/react/src/styles/style.scss
+++ b/packages/read-and-create-calendar-events/frontend/react/src/styles/style.scss
@@ -70,6 +70,7 @@ button {
   align-items: center;
   gap: calc(#{$spacing-16} + #{$spacing-4}/ 2);
   animation: fadeIn 0.5s, fadeOut 5.6s cubic-bezier(0.76, 0, 0.24, 1);
+  min-width: calc(#{$spacing-24} * 14);
 
   &.success {
     background-color: $color-green-50;
@@ -79,9 +80,14 @@ button {
     background-color: $color-red-50;
   }
 
-  img.close {
-    margin-left: $spacing-28;
-    cursor: pointer;
+  .dismiss-container {
+    display: flex;
+    flex: 1;
+    justify-content: flex-end;
+
+    img.close {
+      cursor: pointer;
+    }
   }
 }
 

--- a/packages/send-and-read-emails/frontend/react/src/components/Layout.jsx
+++ b/packages/send-and-read-emails/frontend/react/src/components/Layout.jsx
@@ -45,7 +45,6 @@ const Layout = ({
             <button
               onClick={handleRefresh}
               disabled={isLoading || isDisconnecting || toastNotification}
-              className={toastNotification ? 'hidden' : ''}
             >
               <div className={`menu-icon ${isLoading ? 'syncing' : ''}`}>
                 <IconSync />

--- a/packages/send-and-read-emails/frontend/react/src/components/Layout.jsx
+++ b/packages/send-and-read-emails/frontend/react/src/components/Layout.jsx
@@ -40,11 +40,12 @@ const Layout = ({
           toastNotification={toastNotification}
           setToastNotification={setToastNotification}
         />
-        {showMenu && !toastNotification && (
+        {showMenu && (
           <div className="menu">
             <button
               onClick={handleRefresh}
-              disabled={isLoading || isDisconnecting}
+              disabled={isLoading || isDisconnecting || toastNotification}
+              className={toastNotification ? 'hidden' : ''}
             >
               <div className={`menu-icon ${isLoading ? 'syncing' : ''}`}>
                 <IconSync />
@@ -56,7 +57,7 @@ const Layout = ({
             <div className="hidden-mobile">·</div>
             <button
               onClick={handleDisconnect}
-              disabled={isLoading || isDisconnecting}
+              disabled={isLoading || isDisconnecting || toastNotification}
             >
               <div className="menu-icon">
                 <IconLogout />

--- a/packages/send-and-read-emails/frontend/react/src/components/Toast.jsx
+++ b/packages/send-and-read-emails/frontend/react/src/components/Toast.jsx
@@ -7,11 +7,12 @@ import { useEffect } from 'react';
 
 function Toast({ toastNotification, setToastNotification }) {
   useEffect(() => {
-    setTimeout(() => {
+    const timer = setTimeout(() => {
       if (toastNotification) {
         setToastNotification('');
       }
-    }, 3000);
+    }, 5500);
+    return () => clearTimeout(timer);
   }, [toastNotification]);
 
   const icons = { success: SuccessIcon, error: ErrorIcon, close: CloseIcon };
@@ -25,12 +26,14 @@ function Toast({ toastNotification, setToastNotification }) {
       <div className={`toast ${toastNotification}`}>
         <img src={icons[toastNotification]} alt={toastNotification} />
         {message[toastNotification]}
-        <img
-          src={icons.close}
-          alt="Close"
-          className="close"
-          onClick={() => setToastNotification('')}
-        />
+        <div className="dismiss-container">
+          <img
+            src={icons.close}
+            alt="Close"
+            className="close"
+            onClick={() => setToastNotification('')}
+          />
+        </div>
       </div>
     )
   );

--- a/packages/send-and-read-emails/frontend/react/src/styles/style.scss
+++ b/packages/send-and-read-emails/frontend/react/src/styles/style.scss
@@ -118,6 +118,7 @@ button {
   gap: $spacing-16;
   animation: fadeIn 0.5s, fadeOut 5.6s cubic-bezier(0.76, 0, 0.24, 1);
   min-width: calc(#{$spacing-24} * 14);
+  z-index: 1;
 
   &.success {
     background-color: $color-green-50;

--- a/packages/send-and-read-emails/frontend/react/src/styles/style.scss
+++ b/packages/send-and-read-emails/frontend/react/src/styles/style.scss
@@ -117,7 +117,7 @@ button {
   align-items: center;
   gap: $spacing-16;
   animation: fadeIn 0.5s, fadeOut 5.6s cubic-bezier(0.76, 0, 0.24, 1);
-  min-width: calc($spacing-24 * 13);
+  min-width: calc(#{$spacing-24} * 14);
 
   &.success {
     background-color: $color-green-50;

--- a/packages/send-and-read-emails/frontend/react/src/styles/style.scss
+++ b/packages/send-and-read-emails/frontend/react/src/styles/style.scss
@@ -116,7 +116,8 @@ button {
   display: flex;
   align-items: center;
   gap: $spacing-16;
-  animation: fadeIn 0.5s, fadeOut 2.8s;
+  animation: fadeIn 0.5s, fadeOut 5.6s cubic-bezier(0.76, 0, 0.24, 1);
+  min-width: calc($spacing-24 * 13);
 
   &.success {
     background-color: $color-green-50;
@@ -126,9 +127,14 @@ button {
     background-color: $color-red-50;
   }
 
-  img.close {
-    margin-left: $spacing-48;
-    cursor: pointer;
+  .dismiss-container {
+    display: flex;
+    flex: 1;
+    justify-content: flex-end;
+
+    img.close {
+      cursor: pointer;
+    }
   }
 }
 
@@ -282,6 +288,7 @@ section.login {
     }
   }
 }
+
 .app-card {
   width: 100%;
   height: 100%;

--- a/packages/send-emails/frontend/react/src/components/Toast.jsx
+++ b/packages/send-emails/frontend/react/src/components/Toast.jsx
@@ -11,7 +11,7 @@ function Toast({ toastNotification, setToastNotification }) {
       if (toastNotification) {
         setToastNotification('');
       }
-    }, 3000);
+    }, 5500);
   }, [toastNotification]);
 
   const icons = { success: SuccessIcon, error: ErrorIcon, close: CloseIcon };

--- a/packages/send-emails/frontend/react/src/components/Toast.jsx
+++ b/packages/send-emails/frontend/react/src/components/Toast.jsx
@@ -7,11 +7,12 @@ import { useEffect } from 'react';
 
 function Toast({ toastNotification, setToastNotification }) {
   useEffect(() => {
-    setTimeout(() => {
+    const timer = setTimeout(() => {
       if (toastNotification) {
         setToastNotification('');
       }
     }, 5500);
+    return () => clearTimeout(timer);
   }, [toastNotification]);
 
   const icons = { success: SuccessIcon, error: ErrorIcon, close: CloseIcon };

--- a/packages/send-emails/frontend/react/src/components/Toast.jsx
+++ b/packages/send-emails/frontend/react/src/components/Toast.jsx
@@ -26,12 +26,14 @@ function Toast({ toastNotification, setToastNotification }) {
       <div className={`toast ${toastNotification}`}>
         <img src={icons[toastNotification]} alt={toastNotification} />
         {message[toastNotification]}
-        <img
-          src={icons.close}
-          alt="Close"
-          className="close"
-          onClick={() => setToastNotification('')}
-        />
+        <div className="dismiss-container">
+          <img
+            src={icons.close}
+            alt="Close"
+            className="close"
+            onClick={() => setToastNotification('')}
+          />
+        </div>
       </div>
     )
   );

--- a/packages/send-emails/frontend/react/src/styles/style.scss
+++ b/packages/send-emails/frontend/react/src/styles/style.scss
@@ -118,6 +118,7 @@ button {
   gap: $spacing-16;
   animation: fadeIn 0.5s, fadeOut 5.6s cubic-bezier(0.76, 0, 0.24, 1);
   min-width: calc(#{$spacing-24} * 14);
+  z-index: 1;
 
   &.success {
     background-color: $color-green-50;

--- a/packages/send-emails/frontend/react/src/styles/style.scss
+++ b/packages/send-emails/frontend/react/src/styles/style.scss
@@ -117,6 +117,7 @@ button {
   align-items: center;
   gap: $spacing-16;
   animation: fadeIn 0.5s, fadeOut 5.6s cubic-bezier(0.76, 0, 0.24, 1);
+  min-width: calc(#{$spacing-24} * 14);
 
   &.success {
     background-color: $color-green-50;
@@ -126,9 +127,14 @@ button {
     background-color: $color-red-50;
   }
 
-  img.close {
-    margin-left: $spacing-48;
-    cursor: pointer;
+  .dismiss-container {
+    display: flex;
+    flex: 1;
+    justify-content: flex-end;
+
+    img.close {
+      cursor: pointer;
+    }
   }
 }
 

--- a/packages/send-emails/frontend/react/src/styles/style.scss
+++ b/packages/send-emails/frontend/react/src/styles/style.scss
@@ -116,7 +116,7 @@ button {
   display: flex;
   align-items: center;
   gap: $spacing-16;
-  animation: fadeIn 0.5s, fadeOut 2.8s;
+  animation: fadeIn 0.5s, fadeOut 5.6s cubic-bezier(0.76, 0, 0.24, 1);
 
   &.success {
     background-color: $color-green-50;


### PR DESCRIPTION
# Description
- [x] adjust timing and add `cubic-bezier` function as temp fix for smoothly transitioning toast component in and out of DOM
- [x] add `min-width` to toast so it always covers menu buttons for clean look.

# Before

<p align="center">
<img width="450" alt="Screenshot 2023-02-16 at 11 05 16 AM" src="https://user-images.githubusercontent.com/43771331/219456107-c5deb0c9-1697-4e2f-87c8-6ae6d51ba9da.png">
<img width="450" alt="before" src="https://user-images.githubusercontent.com/43771331/219456472-4b4c2788-a3c6-48a1-bc01-a770f19a974b.gif">
</p>

# After
<p align="center">
<img width="450" alt="after" src="https://user-images.githubusercontent.com/43771331/219457678-a1d92394-9d99-4ae1-83ad-1d1eec5306f0.gif">
</p>

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.