### PR TITLE
Fixed scopes to work with Sandbox Apps

### DIFF
--- a/packages/read-emails/backend/java/src/main/java/Server.java
+++ b/packages/read-emails/backend/java/src/main/java/Server.java
@@ -74,7 +74,7 @@ public class Server {
 					.urlBuilder()
 					.loginHint(requestBody.get("email_address"))
 					.redirectUri(clientUri + requestBody.get("success_url"))
-					.scopes(Scope.EMAIL_READ_ONLY, Scope.EMAIL_MODIFY, Scope.EMAIL_SEND)
+					.scopes(Scope.EMAIL_MODIFY, Scope.EMAIL_SEND)
 					.buildUrl();
 		});
 

--- a/packages/read-emails/backend/node/server.js
+++ b/packages/read-emails/backend/node/server.js
@@ -62,7 +62,7 @@ app.post('/nylas/generate-auth-url', express.json(), async (req, res) => {
   const authUrl = Nylas.urlForAuthentication({
     loginHint: body.email_address,
     redirectURI: (CLIENT_URI || '') + body.success_url,
-    scopes: [Scope.EmailReadOnly],
+    scopes: [Scope.EmailModify],
   });
 
   return res.send(authUrl);

--- a/packages/read-emails/backend/python/server.py
+++ b/packages/read-emails/backend/python/server.py
@@ -78,7 +78,7 @@ def build_auth_url():
     auth_url = nylas.authentication_url(
         (CLIENT_URI or "") + request_body["success_url"],
         login_hint=request_body["email_address"],
-        scopes=['email.read_only'],
+        scopes=['email.modify'],
         state=None,
     )
 

--- a/packages/read-emails/backend/ruby/server.rb
+++ b/packages/read-emails/backend/ruby/server.rb
@@ -80,7 +80,7 @@ post '/nylas/generate-auth-url' do
   # Use the SDK method to generate a Nylas Hosted Authentication URL
   auth_url = nylas.authentication_url(
     redirect_uri: CLIENT_URI + request_body['success_url'],
-    scopes: ['email.read_only'],
+    scopes: ['email.modify'],
     login_hint: request_body['email_address'],
     state: nil
   )

--- a/packages/send-and-read-emails/backend/java/src/main/java/Server.java
+++ b/packages/send-and-read-emails/backend/java/src/main/java/Server.java
@@ -75,7 +75,7 @@ public class Server {
 					.urlBuilder()
 					.loginHint(requestBody.get("email_address"))
 					.redirectUri(clientUri + requestBody.get("success_url"))
-					.scopes(Scope.EMAIL_READ_ONLY, Scope.EMAIL_MODIFY, Scope.EMAIL_SEND)
+					.scopes(Scope.EMAIL_MODIFY, Scope.EMAIL_SEND)
 					.buildUrl();
 		});
 

--- a/packages/send-and-read-emails/backend/node/server.js
+++ b/packages/send-and-read-emails/backend/node/server.js
@@ -69,7 +69,7 @@ app.post('/nylas/generate-auth-url', express.json(), async (req, res) => {
   const authUrl = Nylas.urlForAuthentication({
     loginHint: body.email_address,
     redirectURI: (CLIENT_URI || '') + body.success_url,
-    scopes: [Scope.EmailReadOnly, Scope.EmailModify, Scope.EmailSend],
+    scopes: [Scope.EmailModify, Scope.EmailSend],
   });
 
   return res.send(authUrl);

--- a/packages/send-and-read-emails/backend/python/server.py
+++ b/packages/send-and-read-emails/backend/python/server.py
@@ -82,7 +82,7 @@ def build_auth_url():
     auth_url = nylas.authentication_url(
         (CLIENT_URI or "") + request_body["success_url"],
         login_hint=request_body["email_address"],
-        scopes=['email.send', 'email.modify', 'email.read_only'],
+        scopes=['email.send', 'email.modify'],
         state=None,
     )
 

--- a/packages/send-and-read-emails/backend/ruby/server.rb
+++ b/packages/send-and-read-emails/backend/ruby/server.rb
@@ -80,7 +80,7 @@ post '/nylas/generate-auth-url' do
   # Use the SDK method to generate a Nylas Hosted Authentication URL
   auth_url = nylas.authentication_url(
     redirect_uri: CLIENT_URI + request_body['success_url'],
-    scopes: ['email.send', 'email.modify', 'email.read_only'],
+    scopes: ['email.send', 'email.modify'],
     login_hint: request_body['email_address'],
     state: nil
   )

--- a/packages/send-emails/backend/java/src/main/java/Server.java
+++ b/packages/send-emails/backend/java/src/main/java/Server.java
@@ -73,7 +73,7 @@ public class Server {
 					.urlBuilder()
 					.loginHint(requestBody.get("email_address"))
 					.redirectUri(clientUri + requestBody.get("success_url"))
-					.scopes(Scope.EMAIL_READ_ONLY, Scope.EMAIL_MODIFY, Scope.EMAIL_SEND)
+					.scopes(Scope.EMAIL_MODIFY, Scope.EMAIL_SEND)
 					.buildUrl();
 		});
 


### PR DESCRIPTION
# Description
Some of the scopes being requested were too granular and not included in our Sandbox app Google Verification process. Using these scopes lead to users getting an "App Blocked" error by google.

We're updating the code to use the more "permissive" scopes (e.g. email.read_only -> email.modify) to avoid having the user run into any auth errors while testing these sample apps.

# What did you do?
- [x] Removed all instances of `email.read_only` scopes and replaced it with `email.modify` when necessary

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.